### PR TITLE
Feat: 지원자 API 추가

### DIFF
--- a/src/main/java/com/modong/backend/Applicant/ApplicantController.java
+++ b/src/main/java/com/modong/backend/Applicant/ApplicantController.java
@@ -1,0 +1,61 @@
+package com.modong.backend.Applicant;
+
+import com.modong.backend.Applicant.Dto.ApplicantDetailResponse;
+import com.modong.backend.Applicant.Dto.ApplicantRequest;
+import com.modong.backend.Applicant.Dto.ApplicantSimpleResponse;
+import com.modong.backend.Applicant.Dto.ChangeApplicantStatusRequest;
+import com.modong.backend.Base.Dto.SavedId;
+import com.modong.backend.Base.MessageCode;
+import com.modong.backend.Base.BaseResponse;
+import com.modong.backend.Enum.ApplicantStatus;
+import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@Api(tags =  "지원자 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ApplicantController {
+  private final ApplicantService applicantService;
+
+  @GetMapping("/applicants/{application_id}") // 메인 화면에서 사용할 작성한 지원서 마다 어떤 지원자가 지원했는지 조회할때 사용
+  @Operation(summary = "지원자들 간편 조회", description = "지원서의 ID를 통해 모든 지원자들을 간편 조회 한다.")
+  public ResponseEntity getApplicantsByApplicationId(@Validated @PathVariable(name="application_id") Long applicationId){
+    List<ApplicantSimpleResponse> applicants = applicantService.findAllByApplicationId(applicationId);
+    return ResponseEntity.ok(new BaseResponse(applicants, HttpStatus.OK.value(), MessageCode.SUCCESS_GET_LIST));
+  }
+
+  @GetMapping("/applicant/{applicant_id}") // 각 지원자를 ID로 조회해 질문에 어떤 답을 했는지 알고 싶을때 사용하는 API
+  @Operation(summary = "지원자 답변 조회", description = "지원자를 ID로 조회해 질문에 어떤 답을 했는지 조회 한다.")
+  public ResponseEntity getApplicantById(@Validated @PathVariable(name="applicant_id") Long applicantId){
+    ApplicantDetailResponse applicant = applicantService.findById(applicantId);
+    return ResponseEntity.ok(new BaseResponse(applicant, HttpStatus.OK.value(),MessageCode.SUCCESS_GET));
+  }
+
+  @PatchMapping("/applicant/{applicant_id}")// 지원자의상태를 변경할때 사용하는 API
+  @Operation(summary = "지원자 상태 변경", description = "지원자를 상태를 변경한다.")
+  public ResponseEntity changeApplicantStatus(@Validated @PathVariable(name="applicant_id") Long applicantId, @RequestBody ChangeApplicantStatusRequest applicantStatus){
+    SavedId savedId = new SavedId(applicantService.changeApplicantStatus(applicantId,applicantStatus));
+    return ResponseEntity.ok(new BaseResponse(savedId, HttpStatus.OK.value(), MessageCode.SUCCESS_GET));
+  }
+
+  @PostMapping("/applicant")//지원자 생성과 동시에 답변들 저장하는 API
+  @Operation(summary = "지원자 생성", description = "지원자를 생성하고 답변을 저장한다.")
+  public ResponseEntity createApplicantAndSaveQuestions(@Validated @RequestBody ApplicantRequest applicantRequest){
+    SavedId savedId = new SavedId(applicantService.createApplicant(applicantRequest));
+    return ResponseEntity.ok(new BaseResponse(savedId, HttpStatus.CREATED.value(), MessageCode.SUCCESS_CREATE));
+  }
+}

--- a/src/main/java/com/modong/backend/Applicant/ApplicantRepository.java
+++ b/src/main/java/com/modong/backend/Applicant/ApplicantRepository.java
@@ -1,0 +1,9 @@
+package com.modong.backend.Applicant;
+
+import java.util.ArrayList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicantRepository extends JpaRepository<Applicant,Long> {
+
+  ArrayList<Applicant> findAllByApplicationId(Long applicationId);
+}

--- a/src/main/java/com/modong/backend/Applicant/ApplicantService.java
+++ b/src/main/java/com/modong/backend/Applicant/ApplicantService.java
@@ -1,0 +1,81 @@
+package com.modong.backend.Applicant;
+
+import static com.modong.backend.Base.MessageCode.ERROR_REQ_PARAM_ID;
+
+import com.modong.backend.Applicant.Dto.ApplicantDetailResponse;
+import com.modong.backend.Applicant.Dto.ApplicantRequest;
+import com.modong.backend.Applicant.Dto.ApplicantSimpleResponse;
+import com.modong.backend.Applicant.Dto.ChangeApplicantStatusRequest;
+import com.modong.backend.Application.Application;
+import com.modong.backend.Application.ApplicationService;
+import com.modong.backend.Enum.ApplicantStatus;
+import com.modong.backend.EssentialAnswer.Dto.EssentialAnswerRequest;
+import com.modong.backend.EssentialAnswer.EssentialAnswerService;
+import com.modong.backend.QuestionAnswer.Dto.QuestionAnswerRequest;
+import com.modong.backend.QuestionAnswer.QuestionAnswerService;
+import java.util.stream.Collectors;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ApplicantService {
+
+  private final ApplicantRepository applicantRepository;
+  private final ApplicationService applicationService;
+  private final EssentialAnswerService essentialAnswerService;
+  private final QuestionAnswerService questionAnswerService;
+  public List<ApplicantSimpleResponse> findAllByApplicationId(Long applicationId) {
+    List<ApplicantSimpleResponse> applicants = applicantRepository.findAllByApplicationId(applicationId).stream().map(
+        ApplicantSimpleResponse::new).collect(
+        Collectors.toList());
+    return applicants;
+  }
+
+
+  // 지원자 상세조회
+  public ApplicantDetailResponse findById(Long applicantId) {
+    ApplicantDetailResponse applicant = new ApplicantDetailResponse(applicantRepository.findById(applicantId)
+        .orElseThrow(()-> new IllegalArgumentException(ERROR_REQ_PARAM_ID.toString())));
+
+    return applicant;
+  }
+  @Transactional // 지원자 상태 변경
+  public Long changeApplicantStatus(Long applicantId, ChangeApplicantStatusRequest applicantStatus){
+
+    Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(() -> new IllegalArgumentException(ERROR_REQ_PARAM_ID.toString()));
+
+    applicant.changeStatus(ApplicantStatus.valueOf(applicantStatus.getApplicationStatus()));
+
+    applicantRepository.save(applicant);
+
+    return applicant.getId();
+  }
+  @Transactional // 지원자 생성 및 질문에 대한 답변들 저장
+  public Long createApplicant(ApplicantRequest applicantRequest) {
+
+
+    Application application = applicationService.findSimpleById(applicantRequest.getApplicationId());
+
+    Applicant applicant = new Applicant(applicantRequest, application);
+
+    applicantRepository.save(applicant);
+
+    //필수 질문 저장
+    for(EssentialAnswerRequest essentialAnswerRequest : applicantRequest.getEssentialAnswers()){
+      essentialAnswerService.create(essentialAnswerRequest,applicant);
+    }
+
+    //폼 질문 저장
+    for(QuestionAnswerRequest questionAnswerRequest : applicantRequest.getQuestionAnswers()){
+      questionAnswerService.create(questionAnswerRequest,applicant);
+    }
+
+    return applicant.getId();
+
+  }
+}

--- a/src/main/java/com/modong/backend/Applicant/Dto/ApplicantDetailResponse.java
+++ b/src/main/java/com/modong/backend/Applicant/Dto/ApplicantDetailResponse.java
@@ -1,0 +1,23 @@
+package com.modong.backend.Applicant.Dto;
+
+import com.modong.backend.Applicant.Applicant;
+import com.modong.backend.EssentialAnswer.Dto.EssentialAnswerResponse;
+import com.modong.backend.QuestionAnswer.Dto.QuestionAnswerResponse;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class ApplicantDetailResponse extends ApplicantSimpleResponse {
+  private List<EssentialAnswerResponse> essentialAnswers = new ArrayList<>();
+  private List<QuestionAnswerResponse> questionAnswers = new ArrayList<>();
+
+  public ApplicantDetailResponse(Applicant applicant) {
+    super(applicant);
+    this.essentialAnswers = applicant.getEssentialAnswers().stream().map(EssentialAnswerResponse::new).collect(
+        Collectors.toList());
+    this.questionAnswers = applicant.getQuestionAnswers().stream().map(QuestionAnswerResponse::new).collect(
+        Collectors.toList());
+  }
+}

--- a/src/main/java/com/modong/backend/Applicant/Dto/ApplicantRequest.java
+++ b/src/main/java/com/modong/backend/Applicant/Dto/ApplicantRequest.java
@@ -1,0 +1,29 @@
+package com.modong.backend.Applicant.Dto;
+
+import com.modong.backend.EssentialAnswer.Dto.EssentialAnswerRequest;
+import com.modong.backend.QuestionAnswer.Dto.QuestionAnswerRequest;
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ApplicantRequest {
+
+  @NotNull
+  @Schema(description = "지원서 ID", required = true, example = "1")
+  private Long applicationId;
+
+  @NotNull
+  @Schema(description = "지원자 이름", required = true, example = "홍길동")
+  private String name;
+
+  @Schema(description = "필수 질문 답변들", required = false)
+  private List<EssentialAnswerRequest> essentialAnswers = new ArrayList<>();
+
+  @Schema(description = "질문 답변들", required = false)
+  private List<QuestionAnswerRequest> questionAnswers = new ArrayList<>();
+
+}

--- a/src/main/java/com/modong/backend/Applicant/Dto/ApplicantSimpleResponse.java
+++ b/src/main/java/com/modong/backend/Applicant/Dto/ApplicantSimpleResponse.java
@@ -1,0 +1,24 @@
+package com.modong.backend.Applicant.Dto;
+
+import static com.modong.backend.Utils.DateUtils.asDate;
+
+import com.modong.backend.Applicant.Applicant;
+import java.util.Date;
+import lombok.Getter;
+
+@Getter
+public class ApplicantSimpleResponse {
+  private Long id;
+  private String name;
+  private float rate;
+  private String status;
+  private Date submitDate;
+
+  public ApplicantSimpleResponse(Applicant applicant) {
+    this.id = applicant.getId();
+    this.name = applicant.getName();
+    this.rate = applicant.getRate();
+    this.status = applicant.getApplicantStatus().toString();
+    this.submitDate = asDate(applicant.getCreateDate());
+  }
+}

--- a/src/main/java/com/modong/backend/Applicant/Dto/ChangeApplicantStatusRequest.java
+++ b/src/main/java/com/modong/backend/Applicant/Dto/ChangeApplicantStatusRequest.java
@@ -1,0 +1,11 @@
+package com.modong.backend.Applicant.Dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ChangeApplicantStatusRequest {
+
+  @NotNull
+  private String applicationStatus;
+}

--- a/src/main/java/com/modong/backend/EssentialAnswer/Dto/EssentialAnswerRequest.java
+++ b/src/main/java/com/modong/backend/EssentialAnswer/Dto/EssentialAnswerRequest.java
@@ -1,0 +1,21 @@
+package com.modong.backend.EssentialAnswer.Dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class EssentialAnswerRequest {
+
+
+  @NotNull // 필수 질문 ID
+  @Schema(description = "필수 질문 ID", required = true, example = "1")
+  private Long essentialQuestionId;
+
+  //필수 질문 답변
+  @NotNull
+  @Schema(description = "필수 질문 답변", required = true, example = "필수 질문 답변입니다!")
+  private String answer;
+
+}

--- a/src/main/java/com/modong/backend/EssentialAnswer/EssentialAnswerRepository.java
+++ b/src/main/java/com/modong/backend/EssentialAnswer/EssentialAnswerRepository.java
@@ -1,0 +1,7 @@
+package com.modong.backend.EssentialAnswer;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EssentialAnswerRepository extends JpaRepository<EssentialAnswer, Long> {
+
+}

--- a/src/main/java/com/modong/backend/EssentialAnswer/EssentialAnswerService.java
+++ b/src/main/java/com/modong/backend/EssentialAnswer/EssentialAnswerService.java
@@ -1,0 +1,29 @@
+package com.modong.backend.EssentialAnswer;
+
+import com.modong.backend.Applicant.Applicant;
+import com.modong.backend.Application.Application;
+import com.modong.backend.EssentialAnswer.Dto.EssentialAnswerRequest;
+import com.modong.backend.EssentialQuestion.EssentialQuestion;
+import com.modong.backend.EssentialQuestion.EssentialQuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EssentialAnswerService {
+
+  private final EssentialAnswerRepository essentialAnswerRepository;
+  private final EssentialQuestionService essentialQuestionService;
+  @Transactional
+  public Long create(EssentialAnswerRequest essentialAnswerRequest, Applicant applicant) {
+    EssentialQuestion essentialQuestion = essentialQuestionService.findById(essentialAnswerRequest.getEssentialQuestionId());
+
+    EssentialAnswer essentialAnswer = new EssentialAnswer(essentialAnswerRequest,essentialQuestion,applicant);
+
+    essentialAnswerRepository.save(essentialAnswer);
+
+    return essentialAnswer.getId();
+  }
+}

--- a/src/main/java/com/modong/backend/EssentialQuestion/Dto/EssentialQuestionRequest.java
+++ b/src/main/java/com/modong/backend/EssentialQuestion/Dto/EssentialQuestionRequest.java
@@ -1,0 +1,14 @@
+package com.modong.backend.EssentialQuestion.Dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class EssentialQuestionRequest {
+
+  private Long id;
+  @NotNull
+  private String content;
+  private boolean isRequire;
+
+}

--- a/src/main/java/com/modong/backend/QuestionAnswer/Dto/QuestionAnswerRequest.java
+++ b/src/main/java/com/modong/backend/QuestionAnswer/Dto/QuestionAnswerRequest.java
@@ -1,0 +1,18 @@
+package com.modong.backend.QuestionAnswer.Dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class QuestionAnswerRequest {
+
+  @NotNull  // 질문 ID
+  @Schema(description = "질문 ID", required = true, example = "1")
+  private Long questionId;
+
+  @Schema(description = "질문 답변", required = false, example = "일반 질문 답변입니다!")
+  private String answer;
+
+}

--- a/src/main/java/com/modong/backend/QuestionAnswer/Dto/QuestionAnswerResponse.java
+++ b/src/main/java/com/modong/backend/QuestionAnswer/Dto/QuestionAnswerResponse.java
@@ -1,0 +1,16 @@
+package com.modong.backend.QuestionAnswer.Dto;
+
+import com.modong.backend.EssentialAnswer.EssentialAnswer;
+import com.modong.backend.QuestionAnswer.QuestionAnswer;
+import lombok.Getter;
+
+@Getter
+public class QuestionAnswerResponse {
+  private String essentialQuestion;
+  private String essentialAnswer;
+
+  public QuestionAnswerResponse(QuestionAnswer questionAnswer) {
+    this.essentialQuestion = questionAnswer.getQuestion().getContent();
+    this.essentialAnswer = questionAnswer.getAnswer();
+  }
+}

--- a/src/main/java/com/modong/backend/QuestionAnswer/QuestionAnswerRepository.java
+++ b/src/main/java/com/modong/backend/QuestionAnswer/QuestionAnswerRepository.java
@@ -1,0 +1,7 @@
+package com.modong.backend.QuestionAnswer;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionAnswerRepository extends JpaRepository<QuestionAnswer,Long> {
+
+}

--- a/src/main/java/com/modong/backend/QuestionAnswer/QuestionAnswerService.java
+++ b/src/main/java/com/modong/backend/QuestionAnswer/QuestionAnswerService.java
@@ -1,0 +1,31 @@
+package com.modong.backend.QuestionAnswer;
+
+import com.modong.backend.Applicant.Applicant;
+import com.modong.backend.Question.Question;
+import com.modong.backend.Question.QuestionService;
+import com.modong.backend.QuestionAnswer.Dto.QuestionAnswerRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuestionAnswerService {
+
+  private final QuestionAnswerRepository questionAnswerRepository;
+  private final QuestionService questionService;
+  @Transactional
+  public Long create(QuestionAnswerRequest questionAnswerRequest, Applicant applicant) {
+    Question question = questionService.findById(questionAnswerRequest.getQuestionId());
+
+    QuestionAnswer questionAnswer = new QuestionAnswer(questionAnswerRequest,question,applicant);
+
+    questionAnswerRepository.save(questionAnswer);
+
+    return questionAnswer.getId();
+
+  }
+
+
+}

--- a/src/main/java/com/modong/backend/Utils/DateUtils.java
+++ b/src/main/java/com/modong/backend/Utils/DateUtils.java
@@ -1,0 +1,26 @@
+package com.modong.backend.Utils;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+public class DateUtils {
+
+  public static Date asDate(LocalDate localDate) {
+    return Date.from(localDate.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+  }
+
+  public static Date asDate(LocalDateTime localDateTime) {
+    return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+  }
+
+  public static LocalDate asLocalDate(Date date) {
+    return Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDate();
+  }
+
+  public static LocalDateTime asLocalDateTime(Date date) {
+    return Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDateTime();
+  }
+}


### PR DESCRIPTION
- 지원자들 간편 조회
	- 메인 페이지에서 해당 지원서에 지원한 지원자들을 확인할 때 사용
- 지원자 답변 조회
	- 지원자가 접수한 지원서와 함께 답변한 내용을 동아리 관리자가 열람할 수 있게
- 지원자 상태 변경
	- 총 5개의 상태가 있다.
	- Fail(불합격), Accept(지원 접수), Application(서류 전형), Interview(면접 전형), Success(최종합격)
- 지원자 생성
	- 지원서에 있는 질문들에 대한 답변을 저장