### PR TITLE
Feat: 지원서 페이지 API 추가

### DIFF
--- a/src/main/java/com/modong/backend/Form/FormController.java
+++ b/src/main/java/com/modong/backend/Form/FormController.java
@@ -1,0 +1,76 @@
+package com.modong.backend.Form;
+
+import com.modong.backend.Base.BaseResponse;
+import com.modong.backend.Base.Dto.SavedId;
+import com.modong.backend.Base.MessageCode;
+import com.modong.backend.Form.dto.FormRequest;
+import com.modong.backend.Form.dto.FormResponse;
+import com.modong.backend.Question.Question;
+import com.modong.backend.Question.QuestionService;
+import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@Api(tags =  "지원서 페이지 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class FormController {
+
+  private final FormService formService;
+  //페이지 생성
+  @PostMapping("/form")
+  @Operation(summary = "페이지 생성", description = "지원서에 새로운 페이지를 저장한다.")
+  public ResponseEntity createForm(@Parameter @Validated @RequestBody FormRequest formRequest){
+      SavedId savedId = new SavedId(formService.create(formRequest));
+      return ResponseEntity.ok(new BaseResponse(savedId, HttpStatus.CREATED.value(), MessageCode.SUCCESS_CREATE));
+  }
+  //페이지 수정
+  @PutMapping("/form/{form_id}")
+  @Operation(summary = "페이지 수정", description = "페이지의 ID를 이용해 수정한다.")
+  public ResponseEntity updateForm(@Parameter @Validated @PathVariable(name = "form_id") Long formId, @RequestBody FormRequest formRequest){
+    SavedId savedId = new SavedId(formService.update(formId,formRequest));
+    return ResponseEntity.ok(new BaseResponse(savedId, HttpStatus.OK.value(), MessageCode.SUCCESS_UPDATE));
+  }
+
+
+  //id로 페이지 조회
+  @GetMapping("/form/{form_id}")
+  @Operation(summary = "페이지 조회", description = "페이지의 ID를 이용해 조회한다.")
+  public ResponseEntity getFormById(@Parameter @Validated @PathVariable(name = "form_id") Long formId){
+
+    FormResponse form = formService.findById(formId);
+    return ResponseEntity.ok(new BaseResponse(form,HttpStatus.OK.value(),MessageCode.SUCCESS_GET));
+  }
+
+  //지원서 id로 해당되는 모든 페이지 조회
+  @GetMapping("/forms/{application_id}")
+  @Operation(summary = "지원서 ID 로 해당되는 모든 페이지 조회", description = "지원서 ID를 이용해 포함된 모든 페이지를 조회한다.")
+  public ResponseEntity getFormsByApplicationId(@Parameter @Validated @PathVariable(name = "application_id") Long applicationId){
+    List<FormResponse> forms = formService.findAllByApplicationId(applicationId);
+    return ResponseEntity.ok(new BaseResponse(forms, HttpStatus.OK.value(), MessageCode.SUCCESS_GET_LIST));
+  }
+
+  //지원서의 페이지 삭제
+  @DeleteMapping("/form/{form_id}")
+  @Operation(summary = "페이지 삭제", description = "페이지의 ID를 이용해 삭제한다.")
+  public ResponseEntity deleteFormById(@Parameter @Validated @PathVariable(name = "form_id") Long formId){
+    formService.deleteForm(formId);
+    return ResponseEntity.ok(new BaseResponse(HttpStatus.OK.value(),MessageCode.SUCCESS_DELETE));
+  }
+
+}

--- a/src/main/java/com/modong/backend/Form/FormRepository.java
+++ b/src/main/java/com/modong/backend/Form/FormRepository.java
@@ -1,0 +1,11 @@
+package com.modong.backend.Form;
+
+import com.modong.backend.Application.Application;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface FormRepository extends JpaRepository<Form, Long> {
+
+  List<Form> findAllByApplication(Application application);
+
+}

--- a/src/main/java/com/modong/backend/Form/FormService.java
+++ b/src/main/java/com/modong/backend/Form/FormService.java
@@ -1,0 +1,95 @@
+package com.modong.backend.Form;
+
+import static com.modong.backend.Base.MessageCode.ERROR_REQ_PARAM_ID;
+
+import com.modong.backend.Application.Application;
+import com.modong.backend.Application.ApplicationService;
+import com.modong.backend.Form.dto.FormRequest;
+import com.modong.backend.Form.dto.FormResponse;
+import com.modong.backend.Question.Dto.QuestionRequest;
+import com.modong.backend.Question.Dto.QuestionResponse;
+import com.modong.backend.Question.Question;
+import com.modong.backend.Question.QuestionService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FormService {
+
+  private final FormRepository formRepository;
+  private final QuestionService questionService;
+  private final ApplicationService applicationService;
+
+  @Transactional
+  public Long create(FormRequest formRequest) {
+
+    Application application = applicationService.findSimpleById(formRequest.getApplicationId());
+
+    Form form = new Form(formRequest,application);
+
+    form.getQuestions().clear();
+
+    for(QuestionRequest questionRequest : formRequest.getQuestionRequests()){
+      Question question = questionService.create(questionRequest,form);
+      form.addQuestion(question);
+    }
+
+    formRepository.save(form);
+
+    return form.getId();
+  }
+
+  public FormResponse findById(Long formId) {
+
+    Form form = formRepository.findById(formId).orElseThrow(() -> new IllegalArgumentException(ERROR_REQ_PARAM_ID.toString()));
+
+    return new FormResponse(form);
+  }
+
+  public List<FormResponse> findAllByApplicationId(Long applicationId) {
+
+    Application application = applicationService.findSimpleById(applicationId);
+
+    List<Form> forms = formRepository.findAllByApplication(application);
+
+    List<FormResponse> results = new ArrayList<>();
+
+    for(Form form : forms){
+      results.add(new FormResponse(form));
+    }
+
+    return results;
+  }
+
+  @Transactional
+  public Long update(Long formId, FormRequest formRequest) {
+
+    Form form = formRepository.findById(formId).orElseThrow(() -> new IllegalArgumentException(ERROR_REQ_PARAM_ID.toString()));
+
+    form.updateForm(formRequest);
+    //기존 질문들 삭제
+    form.getQuestions().removeAll(form.getQuestions());
+
+    for(QuestionRequest questionRequest : formRequest.getQuestionRequests()){
+      Question question = questionService.create(questionRequest,form);
+      form.addQuestion(question);
+    }
+
+    formRepository.save(form);
+
+    return form.getId();
+
+  }
+
+  @Transactional
+  public void deleteForm(Long formId) {
+    Form form = formRepository.findById(formId).orElseThrow(() -> new IllegalArgumentException(ERROR_REQ_PARAM_ID.toString()));
+    formRepository.delete(form);
+  }
+}

--- a/src/main/java/com/modong/backend/Form/dto/FormRequest.java
+++ b/src/main/java/com/modong/backend/Form/dto/FormRequest.java
@@ -1,0 +1,24 @@
+package com.modong.backend.Form.dto;
+
+import com.modong.backend.Question.Dto.QuestionRequest;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class FormRequest {
+
+  @NotNull
+  @ApiModelProperty(value = "지원서 ID", required = true, example = "1")
+  private Long applicationId;
+
+  @NotNull
+  @ApiModelProperty(value = "페이지 제목", required = true, example = "첫번째 페이지")
+  private String title;
+
+  @ApiModelProperty(value = "페이지에 들어갈 질문들", required = false)
+  private List<QuestionRequest> questionRequests = new ArrayList<>();
+
+}

--- a/src/main/java/com/modong/backend/Question/Dto/QuestionRequest.java
+++ b/src/main/java/com/modong/backend/Question/Dto/QuestionRequest.java
@@ -1,0 +1,23 @@
+package com.modong.backend.Question.Dto;
+
+import com.modong.backend.QuestionOption.Dto.QuestionOptionRequest;
+import javax.validation.constraints.NotNull;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class QuestionRequest {
+
+  @NotNull
+  @ApiModelProperty(value = "질문 유형", required = true, example = "1", allowableValues = "1,2,3")
+  private int questionType;
+
+  @NotNull
+  @ApiModelProperty(value = "질문 내용", required = true, example = "동아리에 들어와서 어떤걸 경험하고 싶나요?")
+  private String content;
+  @ApiModelProperty(value = "질문 옵션들", required = false)
+  List<QuestionOptionRequest> questionOptionRequests = new ArrayList<>();
+
+}

--- a/src/main/java/com/modong/backend/Question/QuestionRepository.java
+++ b/src/main/java/com/modong/backend/Question/QuestionRepository.java
@@ -1,0 +1,10 @@
+package com.modong.backend.Question;
+
+import com.modong.backend.Form.Form;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question,Long> {
+
+  List<Question> findAllByForm(Form form);
+}

--- a/src/main/java/com/modong/backend/Question/QuestionService.java
+++ b/src/main/java/com/modong/backend/Question/QuestionService.java
@@ -1,0 +1,68 @@
+package com.modong.backend.Question;
+
+import static com.modong.backend.Base.MessageCode.ERROR_REQ_PARAM_ID;
+
+import com.modong.backend.Enum.QuestionType;
+import com.modong.backend.Form.Form;
+import com.modong.backend.QuestionOption.Dto.QuestionOptionRequest;
+import com.modong.backend.QuestionOption.Dto.QuestionOptionResponse;
+import com.modong.backend.QuestionOption.QuestionOption;
+import com.modong.backend.QuestionOption.QuestionOptionService;
+import com.modong.backend.Question.Dto.QuestionRequest;
+import com.modong.backend.Question.Dto.QuestionResponse;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuestionService {
+
+  private final QuestionRepository questionRepository;
+
+  private final QuestionOptionService questionOptionService;
+
+  public Question findById(Long questionId) {
+    Question question = questionRepository.findById(questionId)
+        .orElseThrow(() -> new IllegalArgumentException(ERROR_REQ_PARAM_ID.toString()));
+    return question;
+  }
+
+  // 일단 중복검사 없이 로직 작성 추후에 추가할 수도 있을듯
+  public Question create(QuestionRequest questionRequest, Form form) {
+
+    Question question = new Question(questionRequest,form);
+    question.getQuestionOptions().clear();
+
+    for(QuestionOptionRequest questionOptionRequest : questionRequest.getQuestionOptionRequests()){
+      QuestionOption questionOption = new QuestionOption(questionOptionRequest,question);
+      question.addOption(questionOption);
+    }
+
+    questionRepository.save(question);
+
+    return question;
+  }
+
+  public List<QuestionResponse> findAllByForm(Form form) {
+
+    List<Question> questions = questionRepository.findAllByForm(form);
+
+    List<QuestionResponse> results = new ArrayList<>();
+
+    for(Question question : questions){
+      List<QuestionOptionResponse> options = new ArrayList<>();
+      if(question.getQuestionType() == QuestionType.CHECKBOX_QUESTION ||
+          question.getQuestionType() == QuestionType.RADIO_QUESTION){
+        options = questionOptionService.findAllByQuestion(question);
+      }
+      results.add(new QuestionResponse(question));
+    }
+
+    return results;
+  }
+
+}

--- a/src/main/java/com/modong/backend/QuestionOption/Dto/QuestionOptionRequest.java
+++ b/src/main/java/com/modong/backend/QuestionOption/Dto/QuestionOptionRequest.java
@@ -1,0 +1,12 @@
+package com.modong.backend.QuestionOption.Dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+public class QuestionOptionRequest {
+
+  @ApiModelProperty(value = "선택하는 질문의 옵션 값", required = false, example = "선택 질문의 값입니다.")
+  private String value;
+
+}

--- a/src/main/java/com/modong/backend/QuestionOption/QuestionOptionRepository.java
+++ b/src/main/java/com/modong/backend/QuestionOption/QuestionOptionRepository.java
@@ -1,0 +1,12 @@
+package com.modong.backend.QuestionOption;
+
+import com.modong.backend.Question.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+
+public interface QuestionOptionRepository extends JpaRepository<QuestionOption,Long> {
+
+  List<QuestionOption> findAllByQuestion(Question question);
+
+}

--- a/src/main/java/com/modong/backend/QuestionOption/QuestionOptionService.java
+++ b/src/main/java/com/modong/backend/QuestionOption/QuestionOptionService.java
@@ -1,0 +1,35 @@
+package com.modong.backend.QuestionOption;
+
+import com.modong.backend.QuestionOption.Dto.QuestionOptionRequest;
+import com.modong.backend.QuestionOption.Dto.QuestionOptionResponse;
+import com.modong.backend.Question.Question;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuestionOptionService {
+
+  private final QuestionOptionRepository questionOptionRepository;
+
+  public QuestionOption create(QuestionOptionRequest questionOptionRequest, Question question) {
+    QuestionOption questionOption = new QuestionOption(questionOptionRequest,question);
+
+    questionOptionRepository.save(questionOption);
+
+    return questionOption;
+  }
+
+  public List<QuestionOptionResponse> findAllByQuestion(Question question) {
+
+    List<QuestionOptionResponse> options = questionOptionRepository.findAllByQuestion(question).stream().map(
+        QuestionOptionResponse::new).collect(
+        Collectors.toList());
+    return options;
+
+  }
+}


### PR DESCRIPTION
- 페이지 생성
	- 질문(질문 유형과 질문 내용)들을 받아 페이지를 생성
		- 주관식 질문
		- 객관식으로 하나만 선택하는 질문
		- 객관식으로 복수개를 선택하는 질문
- 페이지 수정
	- 해당 페이지에 원래 있었던 질문을 모두 없애고 받아온 내용을 질문으로 다시 만들어 저장
- 페이지 조회
	- 페이지 id 사용
- 지원서에 들어가는 모든 페이지 조회 (지원서 id 사용)
- 페이지 삭제
	- 포함된 질문도 모두 삭제