### PR TITLE
Fix: 토큰 재발급 요청 2회시 서버에서 오류나는 부분 해결

### DIFF
--- a/src/main/java/com/modong/backend/auth/AuthService.java
+++ b/src/main/java/com/modong/backend/auth/AuthService.java
@@ -65,19 +65,18 @@ public class AuthService {
         new MemberNotFoundException(memberId));
 
     // memberId로 DB에 존재하는 토큰 찾은 후 요청으로 들어온 토큰과 같은지 비교
-    RefreshToken savedToken = refreshTokenRepository.findByMemberId(memberId)
+    RefreshToken findToken = refreshTokenRepository.findByMemberId(memberId)
         .orElseThrow(() ->  new RefreshTokenNotFoundException(memberId));
 
     // 요청으로 받은 토큰과 DB에 존재하는 토큰 같은지 검사
-    if(!tokenRequest.getRefreshToken().equals(savedToken.getRefreshToken())){
+    if(!tokenRequest.getRefreshToken().equals(findToken.getRefreshToken())){
       throw new RefreshTokenNotValidException();
     }
 
-    RefreshToken newToken = new RefreshToken(issueRefreshToken(findMember), findMember.getId());
+    findToken.update(issueRefreshToken(findMember));
+    refreshTokenRepository.save(findToken);
 
-    refreshTokenRepository.save(newToken);
-
-    return new TokenResponse(findMember.getId(), issueAccessToken(findMember), newToken.getRefreshToken());
+    return new TokenResponse(findMember.getId(), issueAccessToken(findMember), findToken.getRefreshToken());
 
   }
 

--- a/src/main/java/com/modong/backend/auth/refreshToken/RefreshToken.java
+++ b/src/main/java/com/modong/backend/auth/refreshToken/RefreshToken.java
@@ -1,6 +1,7 @@
 package com.modong.backend.auth.refreshToken;
 
 import com.modong.backend.auth.member.Member;
+import com.modong.backend.base.BaseTimeEntity;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RefreshToken {
+public class RefreshToken extends BaseTimeEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -29,6 +30,9 @@ public class RefreshToken {
   public RefreshToken(String refreshToken, Long memberId) {
     this.refreshToken = refreshToken;
     this.memberId = memberId;
+  }
+  public void update(String token){
+    this.refreshToken = token;
   }
 
 }


### PR DESCRIPTION
- 기존 : 토큰 재발급 로직이 새로운 리프레쉬 토큰 객체를 생성해서 저장하는 방식이었는데 이렇게 하면 한 회원에 대해 토큰 값이 2개 이상이 되어버린다. 그래서 다시 리프레쉬 토큰을 이용해 토큰을 재발급 받으려고 하면 다음과 같이  유니크해야 member Id로 조회가 가능한 값이 2개 이상있기때문에 오류가 발생하게 된다. nested exception is javax.persistence.NonUniqueResultException: query did not return a unique result 2

- 변경 :  기존의 리프레쉬 토큰  객체에서 토큰 값만 없데이트 하는 방식으로 변경했다.