### PR TITLE
Feat: 동아리 회원이 지원자 평가하는 API 추가 (CRUD)

### DIFF
--- a/src/main/java/com/modong/backend/domain/applicant/Dto/ApplicantSimpleResponse.java
+++ b/src/main/java/com/modong/backend/domain/applicant/Dto/ApplicantSimpleResponse.java
@@ -29,9 +29,14 @@ public class ApplicantSimpleResponse {
     this.ApplicationId = applicant.getApplication().getId();
     this.id = applicant.getId();
     this.name = applicant.getName();
-    this.rate = applicant.getRate();
+    this.rate = getRoundedRate(applicant.getRate()).floatValue();
     this.status = applicant.getApplicantStatus().toString();
     this.submitDate = asDate(applicant.getCreateDate());
     this.isFail = applicant.isFail();
   }
+
+  private Double getRoundedRate(Float rate){
+    return (Math.round(rate*10)/10.0) ;
+  }
+
 }

--- a/src/main/java/com/modong/backend/domain/applicant/repository/ApplicantRepositoryCustom.java
+++ b/src/main/java/com/modong/backend/domain/applicant/repository/ApplicantRepositoryCustom.java
@@ -1,11 +1,14 @@
 package com.modong.backend.domain.applicant.repository;
 
-import com.modong.backend.Enum.ApplicantStatus;
 import com.modong.backend.domain.applicant.Applicant;
 import com.modong.backend.domain.applicant.Dto.SearchApplicantRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ApplicantRepositoryCustom {
+
+  void updateRateByApplicantId(Long applicantId);
+
+  Float getRateByApplicantId(Long applicantId);
   Page<Applicant> searchByApplicationIdAndStatus(Long applicationId, SearchApplicantRequest request, Pageable pageable);
 }

--- a/src/main/java/com/modong/backend/domain/evaluation/Evaluation.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/Evaluation.java
@@ -1,7 +1,10 @@
 package com.modong.backend.domain.evaluation;
 
+import com.modong.backend.base.BaseEntity;
 import com.modong.backend.domain.applicant.Applicant;
 import com.modong.backend.auth.member.Member;
+import com.modong.backend.domain.evaluation.dto.EvaluationCreateRequest;
+import com.modong.backend.domain.evaluation.dto.EvaluationUpdateRequest;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -16,13 +19,12 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Evaluation {
+public class Evaluation extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private float score;
-
+  private Float score;
   @Lob
   private String comment;
 
@@ -31,4 +33,24 @@ public class Evaluation {
 
   @ManyToOne(fetch = FetchType.LAZY)
   private Applicant applicant;
+
+  public Evaluation(EvaluationCreateRequest evaluationCreateRequest, Member member, Applicant applicant) {
+    this.creatorId = member.getId();
+    this.score = evaluationCreateRequest.getScore();
+    this.comment = evaluationCreateRequest.getComment();
+    this.member = member;
+    this.applicant = applicant;
+  }
+
+  public boolean isWriter(Member member){
+    return this.creatorId.equals(member.getId());
+  }
+  public void update(EvaluationUpdateRequest evaluationUpdateRequest){
+    this.score = evaluationUpdateRequest.getNewScore();
+    this.comment = evaluationUpdateRequest.getNewComment();
+  }
+
+  public void delete() {
+    this.isDeleted = true;
+  }
 }

--- a/src/main/java/com/modong/backend/domain/evaluation/EvaluationController.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/EvaluationController.java
@@ -1,0 +1,87 @@
+package com.modong.backend.domain.evaluation;
+
+import com.modong.backend.Enum.CustomCode;
+import com.modong.backend.auth.support.Auth;
+import com.modong.backend.base.Dto.BaseResponse;
+import com.modong.backend.base.Dto.ErrorResponse;
+import com.modong.backend.base.Dto.SavedId;
+import com.modong.backend.domain.evaluation.dto.EvaluationCreateRequest;
+import com.modong.backend.domain.evaluation.dto.EvaluationDeleteRequest;
+import com.modong.backend.domain.evaluation.dto.EvaluationFindRequest;
+import com.modong.backend.domain.evaluation.dto.EvaluationResponse;
+import com.modong.backend.domain.evaluation.dto.EvaluationUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "지원자 평가 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class EvaluationController {
+  private final EvaluationService evaluationService;
+
+  @PostMapping("/evaluation")//평가 생성 API
+  @Operation(summary = "평가 생성", description = "동아리 회원이 지원자를 보고 남긴 평가를 저장한다.", responses = {
+      @ApiResponse(responseCode = "201", description = "평가 생성 성공", content = @Content(schema = @Schema(implementation = SavedId.class))),
+      @ApiResponse(responseCode = "400", description = "평가 생성 실패 - 잘못된 인자, 유효하지 않은 요청", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", description = "평가 생성 실패 - 권한 없음 ", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "평가 생성 실패 - 요청으로 받은 리소스를 찾을 수 없음 ", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity createEvaluation(@Validated @RequestBody EvaluationCreateRequest evaluationCreateRequest, @Auth Long memberId){
+    SavedId savedId = new SavedId(evaluationService.create(evaluationCreateRequest,memberId));
+    return ResponseEntity.created(
+        URI.create("/api/v1/evaluation/" + savedId.getId())).body(new BaseResponse(savedId, HttpStatus.CREATED.value(),
+        CustomCode.SUCCESS_CREATE));
+  }
+  @PutMapping("/evaluation")//평가 수정 API
+  @Operation(summary = "평가 수정", description = "동아리 회원이 지원자를 보고 남긴 평가를 저장한다.", responses = {
+      @ApiResponse(responseCode = "200", description = "평가 수정 성공", content = @Content(schema = @Schema(implementation = SavedId.class))),
+      @ApiResponse(responseCode = "400", description = "평가 수정 실패 - 잘못된 인자, 유효하지 않은 요청", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", description = "평가 수정 실패 - 권한 없음 ", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "평가 수정 실패 - 요청으로 받은 리소스를 찾을 수 없음 ", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity updateEvaluation(@Validated @RequestBody EvaluationUpdateRequest evaluationUpdateRequest, @Auth Long memberId){
+    SavedId savedId = new SavedId(evaluationService.update(evaluationUpdateRequest,memberId));
+    return ResponseEntity.ok(new BaseResponse(savedId,HttpStatus.OK.value(),CustomCode.SUCCESS_UPDATE));
+  }
+  @DeleteMapping("/evaluation")//평가 삭제 API
+  @Operation(summary = "평가 삭제", description = "동아리 회원이 지원자를 보고 남긴 평가를 저장한다.", responses = {
+      @ApiResponse(responseCode = "200", description = "평가 삭제 성공", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+      @ApiResponse(responseCode = "400", description = "평가 삭제 실패 - 잘못된 인자, 유효하지 않은 요청", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", description = "평가 삭제 실패 - 권한 없음 ", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "평가 삭제 실패 - 요청으로 받은 리소스를 찾을 수 없음 ", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity deleteEvaluation(@Validated @RequestBody EvaluationDeleteRequest evaluationDeleteRequest, @Auth Long memberId){
+    evaluationService.delete(evaluationDeleteRequest,memberId);
+    return ResponseEntity.ok(new BaseResponse(HttpStatus.OK.value(),CustomCode.SUCCESS_DELETE));
+  }
+
+  @GetMapping("/evaluations")//평가 조회 API
+  @Operation(summary = "지원자에 대한 전체 평가 조회", description = "동아리 회원이 지원자를 보고 남긴 평가를 저장한다.", responses = {
+      @ApiResponse(responseCode = "200", description = "평가 조회 성공", content = @Content(schema = @Schema(implementation = EvaluationResponse.class))),
+      @ApiResponse(responseCode = "400", description = "평가 조회 실패 - 잘못된 인자, 유효하지 않은 요청", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", description = "평가 조회 실패 - 권한 없음 ", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "평가 조회 실패 - 요청으로 받은 리소스를 찾을 수 없음 ", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity getEvaluationsByApplicant(@Validated EvaluationFindRequest evaluationFindRequest, @Auth Long memberId){
+    List<EvaluationResponse> evaluations = evaluationService.findAllByApplication(evaluationFindRequest,memberId);
+    return ResponseEntity.ok(new BaseResponse(evaluations,HttpStatus.OK.value(),CustomCode.SUCCESS_GET_LIST));
+  }
+
+}

--- a/src/main/java/com/modong/backend/domain/evaluation/EvaluationRepository.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/EvaluationRepository.java
@@ -1,7 +1,11 @@
 package com.modong.backend.domain.evaluation;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
 public interface EvaluationRepository extends JpaRepository<Evaluation,Long> {
 
+  Optional<Evaluation> findByIdAndIsDeletedIsFalse(Long evaluationId);
+
+  List<Evaluation> findAllByApplicantIdAndIsDeletedIsFalse(Long evaluationId);
 }

--- a/src/main/java/com/modong/backend/domain/evaluation/EvaluationRepository.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/EvaluationRepository.java
@@ -8,4 +8,6 @@ public interface EvaluationRepository extends JpaRepository<Evaluation,Long> {
   Optional<Evaluation> findByIdAndIsDeletedIsFalse(Long evaluationId);
 
   List<Evaluation> findAllByApplicantIdAndIsDeletedIsFalse(Long evaluationId);
+
+  Boolean existsByApplicantIdAndMemberId(Long applicantId, Long memberId);
 }

--- a/src/main/java/com/modong/backend/domain/evaluation/EvaluationService.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/EvaluationService.java
@@ -1,2 +1,129 @@
-package com.modong.backend.domain.evaluation;public class EvaluationService {
+package com.modong.backend.domain.evaluation;
+
+import com.modong.backend.auth.member.Member;
+import com.modong.backend.auth.member.MemberRepository;
+import com.modong.backend.domain.applicant.Applicant;
+import com.modong.backend.domain.applicant.repository.ApplicantRepository;
+import com.modong.backend.domain.application.Application;
+import com.modong.backend.domain.application.ApplicationRepository;
+import com.modong.backend.domain.club.clubMemeber.ClubMember;
+import com.modong.backend.domain.evaluation.dto.EvaluationCreateRequest;
+import com.modong.backend.domain.evaluation.dto.EvaluationDeleteRequest;
+import com.modong.backend.domain.evaluation.dto.EvaluationFindRequest;
+import com.modong.backend.domain.evaluation.dto.EvaluationResponse;
+import com.modong.backend.domain.evaluation.dto.EvaluationUpdateRequest;
+import com.modong.backend.global.exception.ResourceNotFoundException;
+import com.modong.backend.global.exception.applicant.ApplicantNotFoundException;
+import com.modong.backend.global.exception.application.ApplicationNotFoundException;
+import com.modong.backend.global.exception.auth.NoPermissionCreateException;
+import com.modong.backend.global.exception.auth.NoPermissionDeleteException;
+import com.modong.backend.global.exception.auth.NoPermissionReadException;
+import com.modong.backend.global.exception.auth.NoPermissionUpdateException;
+import com.modong.backend.global.exception.member.MemberNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EvaluationService {
+  private final EvaluationRepository evaluationRepository;
+  private final MemberRepository memberRepository;
+  private final ApplicantRepository applicantRepository;
+  private final ApplicationRepository applicationRepository;
+
+  @Transactional
+  public Long create(EvaluationCreateRequest evaluationCreateRequest, Long memberId) {
+    Long applicationId = evaluationCreateRequest.getApplicationId();
+    Long applicantId = evaluationCreateRequest.getApplicantId();
+
+    //회원 조회 실패시 에러 반환
+    Member member = memberRepository.findByIdAndIsDeletedIsFalse(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+    //지원자 조회 실패시 에러 반환
+    Applicant applicant = applicantRepository.findByIdAndIsDeletedIsFalse(applicantId).orElseThrow(() -> new ApplicantNotFoundException(applicantId));
+    //지원서 조회 실패시 에러 반환
+    Application application = applicationRepository.findByIdAndIsDeletedIsFalse(applicationId).orElseThrow(() -> new ApplicationNotFoundException(applicationId));
+
+    //회원이 지원자에 대해 평가할 권한이 있는지를 확인하기 위해 동아리가 같은지 비교
+    for(ClubMember clubMember : member.getClubs()){
+      if(application.getClub().getId().equals(clubMember.getClub().getId())){
+        Evaluation evaluation = new Evaluation(evaluationCreateRequest,member,applicant);
+        Evaluation saved = evaluationRepository.save(evaluation);
+        return saved.getId();
+      }
+    }
+    throw new NoPermissionCreateException();
+  }
+
+  @Transactional
+  public Long update(EvaluationUpdateRequest evaluationUpdateRequest, Long memberId) {
+    Long evaluationId = evaluationUpdateRequest.getEvaluationId();
+    //회원 조회 실패시 에러 반환
+    Member member = memberRepository.findByIdAndIsDeletedIsFalse(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+
+    //평가 조회 실패시 에러 반환
+    Evaluation evaluation = evaluationRepository.findByIdAndIsDeletedIsFalse(evaluationId).orElseThrow(() -> new ResourceNotFoundException("Evaluation",evaluationId));
+
+    //작성자가 회원이 맞는지 검증
+    if(evaluation.isWriter(member)){
+      evaluation.update(evaluationUpdateRequest);
+      Evaluation saved = evaluationRepository.save(evaluation);
+      return saved.getId();
+    }
+    else throw new NoPermissionUpdateException();
+  }
+
+  @Transactional
+  public void delete(EvaluationDeleteRequest evaluationDeleteRequest, Long memberId) {
+    Long evaluationId = evaluationDeleteRequest.getEvaluationId();
+    //회원 조회 실패시 에러 반환
+    Member member = memberRepository.findByIdAndIsDeletedIsFalse(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+
+    //평가 조회 실패시 에러 반환
+    Evaluation evaluation = evaluationRepository.findByIdAndIsDeletedIsFalse(evaluationId).orElseThrow(() -> new ResourceNotFoundException("Evaluation",evaluationId));
+
+    //작성자가 회원이 맞는지 검증
+    if(evaluation.isWriter(member)){
+      evaluation.delete();
+      evaluationRepository.save(evaluation);
+    }
+    else throw new NoPermissionDeleteException();
+  }
+  public List<EvaluationResponse> findAllByApplication(EvaluationFindRequest evaluationFindRequest, Long memberId) {
+    Long applicationId = evaluationFindRequest.getApplicationId();
+    Long applicantId = evaluationFindRequest.getApplicantId();
+    //회원 조회 실패시 에러 반환
+    Member member = memberRepository.findByIdAndIsDeletedIsFalse(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+    //지원자 조회 실패시 에러 반환
+    Applicant applicant = applicantRepository.findByIdAndIsDeletedIsFalse(applicantId).orElseThrow(() -> new ApplicantNotFoundException(applicantId));
+    //지원서 조회 실패시 에러 반환
+    Application application = applicationRepository.findByIdAndIsDeletedIsFalse(applicationId).orElseThrow(() -> new ApplicationNotFoundException(applicationId));
+
+    boolean havePermission = false;
+    List<Evaluation> evaluations = new ArrayList<>();
+
+    //회원이 지원자에 대한 평가를 조회할 권한이 있는지를 동아리가 같은지 비교
+    for(ClubMember clubMember : member.getClubs()){
+      if(applicant.getApplication().getClub().equals(clubMember.getClub())){
+        havePermission = true;
+        break;
+      }
+    }
+
+    if(havePermission){
+      List<EvaluationResponse> result = new ArrayList<>();
+      evaluations = evaluationRepository.findAllByApplicantIdAndIsDeletedIsFalse(applicant.getId());
+      for(Evaluation evaluation : evaluations){
+        Member writer = evaluation.getMember();
+        result.add(new EvaluationResponse(evaluation,writer,application.getId(),applicant.getId()));
+      }
+      return result;
+    }
+    else{
+      throw new NoPermissionReadException();
+    }
+  }
 }

--- a/src/main/java/com/modong/backend/domain/evaluation/EvaluationService.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/EvaluationService.java
@@ -3,7 +3,9 @@ package com.modong.backend.domain.evaluation;
 import com.modong.backend.auth.member.Member;
 import com.modong.backend.auth.member.MemberRepository;
 import com.modong.backend.domain.applicant.Applicant;
+import com.modong.backend.domain.applicant.ApplicantService;
 import com.modong.backend.domain.applicant.repository.ApplicantRepository;
+import com.modong.backend.domain.applicant.repository.ApplicantRepositoryCustomImpl;
 import com.modong.backend.domain.application.Application;
 import com.modong.backend.domain.application.ApplicationRepository;
 import com.modong.backend.domain.club.clubMemeber.ClubMember;
@@ -19,6 +21,7 @@ import com.modong.backend.global.exception.auth.NoPermissionCreateException;
 import com.modong.backend.global.exception.auth.NoPermissionDeleteException;
 import com.modong.backend.global.exception.auth.NoPermissionReadException;
 import com.modong.backend.global.exception.auth.NoPermissionUpdateException;
+import com.modong.backend.global.exception.evaluation.AlreadyExistsException;
 import com.modong.backend.global.exception.member.MemberNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +38,8 @@ public class EvaluationService {
   private final ApplicantRepository applicantRepository;
   private final ApplicationRepository applicationRepository;
 
+  private final ApplicantRepositoryCustomImpl applicantRepositoryCustomImpl;
+
   @Transactional
   public Long create(EvaluationCreateRequest evaluationCreateRequest, Long memberId) {
     Long applicationId = evaluationCreateRequest.getApplicationId();
@@ -46,12 +51,17 @@ public class EvaluationService {
     Applicant applicant = applicantRepository.findByIdAndIsDeletedIsFalse(applicantId).orElseThrow(() -> new ApplicantNotFoundException(applicantId));
     //지원서 조회 실패시 에러 반환
     Application application = applicationRepository.findByIdAndIsDeletedIsFalse(applicationId).orElseThrow(() -> new ApplicationNotFoundException(applicationId));
+    //이미 평가한 내용이 있다면 에러 반환
+    if(evaluationRepository.existsByApplicantIdAndMemberId(applicantId,memberId)){
+      throw new AlreadyExistsException("평가");
+    }
 
     //회원이 지원자에 대해 평가할 권한이 있는지를 확인하기 위해 동아리가 같은지 비교
     for(ClubMember clubMember : member.getClubs()){
       if(application.getClub().getId().equals(clubMember.getClub().getId())){
         Evaluation evaluation = new Evaluation(evaluationCreateRequest,member,applicant);
         Evaluation saved = evaluationRepository.save(evaluation);
+        applicantRepositoryCustomImpl.updateRateByApplicantId(applicantId);
         return saved.getId();
       }
     }
@@ -71,6 +81,7 @@ public class EvaluationService {
     if(evaluation.isWriter(member)){
       evaluation.update(evaluationUpdateRequest);
       Evaluation saved = evaluationRepository.save(evaluation);
+      applicantRepositoryCustomImpl.updateRateByApplicantId(evaluationUpdateRequest.getApplicantId());
       return saved.getId();
     }
     else throw new NoPermissionUpdateException();
@@ -89,6 +100,7 @@ public class EvaluationService {
     if(evaluation.isWriter(member)){
       evaluation.delete();
       evaluationRepository.save(evaluation);
+      applicantRepositoryCustomImpl.updateRateByApplicantId(evaluationDeleteRequest.getApplicantId());
     }
     else throw new NoPermissionDeleteException();
   }

--- a/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationCreateRequest.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationCreateRequest.java
@@ -1,22 +1,34 @@
 package com.modong.backend.domain.evaluation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(name = "평가 생성 요청")
 public class EvaluationCreateRequest {
 
+  @Schema(description = "지원서 ID",  example = "1")
+  @NotNull(message = "지원서 id는 필수 항목입니다!")
   private Long applicationId;
+  @Schema(description = "지원자 ID",  example = "2")
+  @NotNull(message = "지원자 id는 필수 항목입니다!")
   private Long applicantId;
 
+  @Schema(description = "평가 점수(소수점1자리까지)",  example = "9.6")
+  @NotNull(message = "점수는 필수 항목입니다!")
   private float score;
+  @Schema(description = "간단한 평가 내용",  example = "맘에 들어요 ~!@")
+  private String comment;
 
   @Builder
-  public EvaluationCreateRequest(Long applicationId, Long applicantId, float score) {
+  public EvaluationCreateRequest(Long applicationId, Long applicantId, float score, String comment) {
     this.applicationId = applicationId;
     this.applicantId = applicantId;
     this.score = score;
+    this.comment = comment;
   }
 }

--- a/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationDeleteRequest.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationDeleteRequest.java
@@ -1,0 +1,24 @@
+package com.modong.backend.domain.evaluation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(name = "평가 삭제 요청")
+public class EvaluationDeleteRequest {
+
+  @Schema(description = "평가 ID",  example = "1")
+  @NotNull(message = "평가 id는 필수 항목입니다!")
+  private Long evaluationId;
+
+  @Builder
+  public EvaluationDeleteRequest(Long evaluationId) {
+    this.evaluationId = evaluationId;
+  }
+
+
+}

--- a/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationDeleteRequest.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationDeleteRequest.java
@@ -15,9 +15,15 @@ public class EvaluationDeleteRequest {
   @NotNull(message = "평가 id는 필수 항목입니다!")
   private Long evaluationId;
 
+  @Schema(description = "지원자 ID",  example = "2")
+  @NotNull(message = "지원자 id는 필수 항목입니다!")
+  private Long applicantId;
+
+
   @Builder
-  public EvaluationDeleteRequest(Long evaluationId) {
+  public EvaluationDeleteRequest(Long evaluationId,Long applicantId) {
     this.evaluationId = evaluationId;
+    this.applicantId = applicantId;
   }
 
 

--- a/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationFindRequest.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationFindRequest.java
@@ -1,0 +1,28 @@
+package com.modong.backend.domain.evaluation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Schema(name = "평가 조회 요청")
+public class EvaluationFindRequest {
+
+  @Schema(description = "지원서 ID",  example = "1")
+  @NotNull(message = "지원서 id는 필수 항목입니다!")
+  private Long applicationId;
+  @Schema(description = "지원자 ID",  example = "2")
+  @NotNull(message = "지원자 id는 필수 항목입니다!")
+  private Long applicantId;
+
+
+
+  @Builder
+  public EvaluationFindRequest(Long applicantId, Long applicationId) {
+    this.applicantId = applicantId;
+    this.applicationId = applicationId;
+  }
+}

--- a/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationResponse.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationResponse.java
@@ -1,0 +1,36 @@
+package com.modong.backend.domain.evaluation.dto;
+
+import com.modong.backend.auth.member.Member;
+import com.modong.backend.domain.evaluation.Evaluation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(name = "평가 조회")
+public class EvaluationResponse {
+  @Schema(description = "평가 id", example = "1")
+  private Long id;
+
+  @Schema(description = "지원서 id", example = "2")
+  private Long applicationId;
+
+  @Schema(description = "지원자 id", example = "3")
+  private Long applicantId;
+  @Schema(description = "작성자 id", example = "4")
+  private Long writerId;
+  @Schema(description = "작성자 회원 아이디", example = "test123")
+  private String writerMemberId;
+  @Schema(description = "작성자 회원 이름", example = "tester")
+  private String writerName;
+  @Schema(description = "평가 내용", example = "면접 질문 : 나이가 어떻게 되시나요?")
+  private String content;
+  public EvaluationResponse(Evaluation evaluation, Member member, Long applicationId, Long applicantId) {
+    this.id = evaluation.getId();
+    this.writerId = evaluation.getCreatorId();
+    this.writerMemberId = member.getMemberId();
+    this.writerName = member.getName();
+    this.content = evaluation.getComment();
+    this.applicantId = applicantId;
+    this.applicationId = applicationId;
+  }
+}

--- a/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationResponse.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationResponse.java
@@ -22,15 +22,18 @@ public class EvaluationResponse {
   private String writerMemberId;
   @Schema(description = "작성자 회원 이름", example = "tester")
   private String writerName;
-  @Schema(description = "평가 내용", example = "면접 질문 : 나이가 어떻게 되시나요?")
-  private String content;
+  @Schema(description = "평가 내용", example = "좋아요 !")
+  private String comment;
+  @Schema(description = "평가 점수", example = "9.6")
+  private float score;
   public EvaluationResponse(Evaluation evaluation, Member member, Long applicationId, Long applicantId) {
     this.id = evaluation.getId();
     this.writerId = evaluation.getCreatorId();
     this.writerMemberId = member.getMemberId();
     this.writerName = member.getName();
-    this.content = evaluation.getComment();
+    this.comment = evaluation.getComment();
     this.applicantId = applicantId;
     this.applicationId = applicationId;
+    this.score = evaluation.getScore();
   }
 }

--- a/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationUpdateRequest.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationUpdateRequest.java
@@ -18,11 +18,17 @@ public class EvaluationUpdateRequest {
   private String newComment;
   @Schema(description = "바뀐 평가 점수",  example = "9.6f")
   private float newScore;
+  @Schema(description = "지원자 ID",  example = "2")
+  @NotNull(message = "지원자 id는 필수 항목입니다!")
+  private Long applicantId;
+
+
 
   @Builder
-  public EvaluationUpdateRequest(Long evaluationId,String newComment, float newScore) {
+  public EvaluationUpdateRequest(Long evaluationId,String newComment, float newScore, Long applicantId) {
     this.newComment = newComment;
     this.evaluationId = evaluationId;
     this.newScore = newScore;
+    this.applicantId = applicantId;
   }
 }

--- a/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationUpdateRequest.java
+++ b/src/main/java/com/modong/backend/domain/evaluation/dto/EvaluationUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.modong.backend.domain.evaluation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(name = "평가 수정 요청")
+public class EvaluationUpdateRequest {
+
+  @Schema(description = "평가 ID",  example = "1")
+  @NotNull(message = "평가 id는 필수 항목입니다!")
+  private Long evaluationId;
+  @Schema(description = "간단한 평가 내용",  example = "맘에 들어요 ~!@")
+  private String newComment;
+  @Schema(description = "바뀐 평가 점수",  example = "9.6f")
+  private float newScore;
+
+  @Builder
+  public EvaluationUpdateRequest(Long evaluationId,String newComment, float newScore) {
+    this.newComment = newComment;
+    this.evaluationId = evaluationId;
+    this.newScore = newScore;
+  }
+}

--- a/src/main/java/com/modong/backend/global/exception/auth/NoPermissionUpdateException.java
+++ b/src/main/java/com/modong/backend/global/exception/auth/NoPermissionUpdateException.java
@@ -2,7 +2,7 @@ package com.modong.backend.global.exception.auth;
 
 public class NoPermissionUpdateException extends NoPermissionException {
 
-  private static final String SERVER_MESSAGE = "수할 권한이 없습니다!";
+  private static final String SERVER_MESSAGE = "수정할 권한이 없습니다!";
   private static final String ERROR_CODE = "NO_PERMISSION_TO_CREATE";
   private static final String CLIENT_MESSAGE = "수정할 권한이 없습니다!";
 

--- a/src/main/java/com/modong/backend/global/exception/evaluation/AlreadyExistsException.java
+++ b/src/main/java/com/modong/backend/global/exception/evaluation/AlreadyExistsException.java
@@ -1,0 +1,13 @@
+package com.modong.backend.global.exception.evaluation;
+
+import com.modong.backend.global.exception.BadRequestException;
+
+public class AlreadyExistsException extends BadRequestException {
+  private static final String SERVER_MESSAGE = "이미 %s가 있습니다.";
+  private static final String ERROR_CODE = "ALREADY_EXISTS";
+  private static final String CLIENT_MESSAGE = "이미 %s가 있습니다.";
+
+  public AlreadyExistsException(String domain) {
+    super(String.format(SERVER_MESSAGE, domain), ERROR_CODE, String.format(CLIENT_MESSAGE, domain));
+  }
+}

--- a/src/test/java/com/modong/backend/Fixtures/ApplicantFixture.java
+++ b/src/test/java/com/modong/backend/Fixtures/ApplicantFixture.java
@@ -5,4 +5,6 @@ public class ApplicantFixture {
   public static final Long APPLICANT_ID = 5L;
   public static final String APPLICANT_NAME = "홍길동";
 
+  public static final Float APPLICANT_RATE = 7.8f;
+
 }

--- a/src/test/java/com/modong/backend/Fixtures/EvaluationFixture.java
+++ b/src/test/java/com/modong/backend/Fixtures/EvaluationFixture.java
@@ -1,0 +1,22 @@
+package com.modong.backend.Fixtures;
+
+public class EvaluationFixture {
+
+  public static Long EVALUATION_ID = 20L;
+
+  public static Long EVALUATION_A_ID = 21L;
+  public static Long EVALUATION_B_ID = 22L;
+  public static Long EVALUATION_C_ID = 23L;
+
+  public static float SCORE = 8.3f;
+  public static String COMMENT = "맘에 드네요 !";
+  public static String UPDATE_COMMENT = "업데이트에요 !";
+  public static float SCORE_A = 9.5f;
+  public static String COMMENT_A = "바로 합격 시키죠 ㅋ";
+  public static String UPDATE_COMMENT_A = "업데이트 A!";
+  public static float SCORE_B = 3.5f;
+  public static String COMMENT_B = "별로에요";
+  public static float SCORE_C = 8.0f;
+  public static String COMMENT_C = "동아리 활동에 적극적일 거 같아요 !";
+
+}

--- a/src/test/java/com/modong/backend/Fixtures/MemberFixture.java
+++ b/src/test/java/com/modong/backend/Fixtures/MemberFixture.java
@@ -2,11 +2,26 @@ package com.modong.backend.Fixtures;
 
 public class MemberFixture {
   public static final Long ID = 1L;
+  public static final Long MEMBER_A_ID = 2L;
+  public static final Long MEMBER_B_ID = 3L;
+  public static final Long MEMBER_C_ID = 4L;
   public static final String MEMBER_ID = "test123";
+  public static final String MEMBER_A_MEMBER_ID = "test123_a";
+  public static final String MEMBER_B_MEMBER_ID = "test123_b";
+  public static final String MEMBER_C_MEMBER_ID = "test123_c";
   public static final String PASSWORD = "myPassword1234!";
   public static final String EMAIL = "email@naver.com";
+  public static final String MEMBER_A_EMAIL = "emaila@naver.com";
+  public static final String MEMBER_B_EMAIL = "emailb@naver.com";
+  public static final String MEMBER_C_EMAIL = "emailc@naver.com";
   public static final String PHONE = "01032343243";
+  public static final String MEMBER_A_PHONE = "01032343213";
+  public static final String MEMBER_B_PHONE = "01032343223";
+  public static final String MEMBER_C_PHONE = "01032343233";
   public static final String NAME = "tester";
+  public static final String MEMBER_A_NAME = "tester_a";
+  public static final String MEMBER_B_NAME = "tester_b";
+  public static final String MEMBER_C_NAME = "tester_c";
 
   public static final String WRONG_MEMBER_ID = "23"; // 길이가 3미만임.
   public static final String WRONG_PASSWORD = "myPass234"; // 특수 문자 없음

--- a/src/test/java/com/modong/backend/unit/base/ServiceTest.java
+++ b/src/test/java/com/modong/backend/unit/base/ServiceTest.java
@@ -56,6 +56,7 @@ import com.modong.backend.auth.member.MemberRepository;
 import com.modong.backend.auth.refreshToken.RefreshTokenRepository;
 import com.modong.backend.domain.applicant.Dto.ApplicantCreateRequest;
 import com.modong.backend.domain.applicant.repository.ApplicantRepository;
+import com.modong.backend.domain.applicant.repository.ApplicantRepositoryCustomImpl;
 import com.modong.backend.domain.application.ApplicationRepository;
 import com.modong.backend.domain.application.Dto.ApplicationCreateRequest;
 import com.modong.backend.domain.application.Dto.ApplicationUpdateRequest;
@@ -109,6 +110,9 @@ public class ServiceTest {
 
   @MockBean
   protected ApplicantRepository applicantRepository;
+
+  @MockBean
+  protected ApplicantRepositoryCustomImpl applicantRepositoryCustom;
 
   @MockBean
   protected MemoRepository memoRepository;

--- a/src/test/java/com/modong/backend/unit/base/ServiceTest.java
+++ b/src/test/java/com/modong/backend/unit/base/ServiceTest.java
@@ -14,7 +14,31 @@ import static com.modong.backend.Fixtures.ClubFixture.CLUB_NAME;
 import static com.modong.backend.Fixtures.ClubFixture.CLUB_PROFILE_IMG_URL;
 import static com.modong.backend.Fixtures.EssentialAnswerFixture.ESSENTIAL_ANSWER;
 import static com.modong.backend.Fixtures.EssentialQuestionFixture.ESSENTIAL_QUESTION_ID;
+import static com.modong.backend.Fixtures.EvaluationFixture.COMMENT;
+import static com.modong.backend.Fixtures.EvaluationFixture.COMMENT_A;
+import static com.modong.backend.Fixtures.EvaluationFixture.COMMENT_B;
+import static com.modong.backend.Fixtures.EvaluationFixture.COMMENT_C;
+import static com.modong.backend.Fixtures.EvaluationFixture.EVALUATION_A_ID;
+import static com.modong.backend.Fixtures.EvaluationFixture.EVALUATION_ID;
+import static com.modong.backend.Fixtures.EvaluationFixture.SCORE;
+import static com.modong.backend.Fixtures.EvaluationFixture.SCORE_A;
+import static com.modong.backend.Fixtures.EvaluationFixture.SCORE_B;
+import static com.modong.backend.Fixtures.EvaluationFixture.SCORE_C;
+import static com.modong.backend.Fixtures.EvaluationFixture.UPDATE_COMMENT;
+import static com.modong.backend.Fixtures.EvaluationFixture.UPDATE_COMMENT_A;
 import static com.modong.backend.Fixtures.MemberFixture.EMAIL;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_A_EMAIL;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_A_MEMBER_ID;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_A_NAME;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_A_PHONE;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_B_EMAIL;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_B_MEMBER_ID;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_B_NAME;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_B_PHONE;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_C_EMAIL;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_C_MEMBER_ID;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_C_NAME;
+import static com.modong.backend.Fixtures.MemberFixture.MEMBER_C_PHONE;
 import static com.modong.backend.Fixtures.MemberFixture.MEMBER_ID;
 import static com.modong.backend.Fixtures.MemberFixture.NAME;
 import static com.modong.backend.Fixtures.MemberFixture.PASSWORD;
@@ -42,6 +66,9 @@ import com.modong.backend.domain.essentialQuestion.EssentialQuestion;
 import com.modong.backend.domain.essentialQuestion.EssentialQuestionRepository;
 import com.modong.backend.domain.evaluation.EvaluationRepository;
 import com.modong.backend.domain.evaluation.dto.EvaluationCreateRequest;
+import com.modong.backend.domain.evaluation.dto.EvaluationDeleteRequest;
+import com.modong.backend.domain.evaluation.dto.EvaluationFindRequest;
+import com.modong.backend.domain.evaluation.dto.EvaluationUpdateRequest;
 import com.modong.backend.domain.memo.MemoRepository;
 import com.modong.backend.domain.memo.dto.MemoCreateRequest;
 import com.modong.backend.domain.memo.dto.MemoDeleteRequest;
@@ -97,7 +124,19 @@ public class ServiceTest {
   protected MemberRegisterRequest memberRegisterRequest = MemberRegisterRequest.builder()
       .memberId(MEMBER_ID).email(EMAIL).password(PASSWORD)
       .phone(PHONE).name(NAME).clubCode(CLUB_CODE).build();
-  
+
+  protected MemberRegisterRequest memberRegisterRequest_userA = MemberRegisterRequest.builder()
+      .memberId(MEMBER_A_MEMBER_ID).email(MEMBER_A_EMAIL).password(PASSWORD)
+      .phone(MEMBER_A_PHONE).name(MEMBER_A_NAME).clubCode(CLUB_CODE).build();
+
+  protected MemberRegisterRequest memberRegisterRequest_userB = MemberRegisterRequest.builder()
+      .memberId(MEMBER_B_MEMBER_ID).email(MEMBER_B_EMAIL).password(PASSWORD)
+      .phone(MEMBER_B_PHONE).name(MEMBER_B_NAME).clubCode(CLUB_CODE).build();
+
+  protected MemberRegisterRequest memberRegisterRequest_userC = MemberRegisterRequest.builder()
+      .memberId(MEMBER_C_MEMBER_ID).email(MEMBER_C_EMAIL).password(PASSWORD)
+      .phone(MEMBER_C_PHONE).name(MEMBER_C_NAME).clubCode(CLUB_CODE).build();
+
   protected ClubCreateRequest clubCreateRequest = ClubCreateRequest.builder()
       .name(CLUB_NAME).profileImgUrl(CLUB_PROFILE_IMG_URL).build();
   protected ApplicationCreateRequest applicationCreateRequest = ApplicationCreateRequest.builder()
@@ -136,6 +175,43 @@ public class ServiceTest {
       .build();
 
   protected EvaluationCreateRequest evaluationCreateRequest = EvaluationCreateRequest.builder()
+      .applicantId(APPLICANT_ID)
+      .applicationId(APPLICATION_ID)
+      .comment(COMMENT)
+      .score(SCORE)
+      .build();
+  protected EvaluationCreateRequest evaluationCreateRequest_userA = EvaluationCreateRequest.builder()
+      .applicantId(APPLICANT_ID)
+      .applicationId(APPLICATION_ID)
+      .comment(COMMENT_A)
+      .score(SCORE_A)
+      .build();
+  protected EvaluationCreateRequest evaluationCreateRequest_userB = EvaluationCreateRequest.builder()
+      .applicantId(APPLICANT_ID)
+      .applicationId(APPLICATION_ID)
+      .comment(COMMENT_B)
+      .score(SCORE_B)
+      .build();
+  protected EvaluationCreateRequest evaluationCreateRequest_userC = EvaluationCreateRequest.builder()
+      .applicantId(APPLICANT_ID)
+      .applicationId(APPLICATION_ID)
+      .comment(COMMENT_C)
+      .score(SCORE_C)
+      .build();
+
+  protected EvaluationUpdateRequest evaluationUpdateRequest = EvaluationUpdateRequest.builder()
+      .evaluationId(EVALUATION_ID)
+      .newComment(UPDATE_COMMENT)
+      .preScore(SCORE)
+      .newScore(SCORE + 1.0f)
+      .build();
+  protected EvaluationDeleteRequest evaluationDeleteRequest = EvaluationDeleteRequest.builder()
+      .evaluationId(EVALUATION_ID)
+      .build();
+
+  protected EvaluationFindRequest evaluationFindRequest = EvaluationFindRequest.builder()
+      .applicantId(APPLICANT_ID)
+      .applicationId(APPLICATION_ID)
       .build();
 
 }

--- a/src/test/java/com/modong/backend/unit/base/ServiceTest.java
+++ b/src/test/java/com/modong/backend/unit/base/ServiceTest.java
@@ -202,7 +202,6 @@ public class ServiceTest {
   protected EvaluationUpdateRequest evaluationUpdateRequest = EvaluationUpdateRequest.builder()
       .evaluationId(EVALUATION_ID)
       .newComment(UPDATE_COMMENT)
-      .preScore(SCORE)
       .newScore(SCORE + 1.0f)
       .build();
   protected EvaluationDeleteRequest evaluationDeleteRequest = EvaluationDeleteRequest.builder()

--- a/src/test/java/com/modong/backend/unit/domain/evaluation/EvaluationServiceTest.java
+++ b/src/test/java/com/modong/backend/unit/domain/evaluation/EvaluationServiceTest.java
@@ -189,9 +189,9 @@ public class EvaluationServiceTest extends ServiceTest {
     given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
     given(evaluationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(evaluation));
     //수정 권한 없게 설정
-    ReflectionTestUtils.setField(evaluation,"writerId", member.getId()+1L);
+    ReflectionTestUtils.setField(evaluation,"creatorId", member.getId()+1L);
     //then
-    assertThatThrownBy(() -> evaluationService.update(memoUpdateRequest,MemberFixture.ID))
+    assertThatThrownBy(() -> evaluationService.update(evaluationUpdateRequest,MemberFixture.ID))
         .isInstanceOf(NoPermissionUpdateException.class);
   }
   @DisplayName("평가 삭제 성공")
@@ -204,10 +204,10 @@ public class EvaluationServiceTest extends ServiceTest {
     given(evaluationRepository.save(any())).willReturn(evaluation);
 
     //when
-    evaluationService.delete(evaluationDeleteRequest,member);
+    evaluationService.delete(evaluationDeleteRequest,MemberFixture.ID);
 
     //then
-    assertThatCode(() -> evaluationService.delete(evaluationDeleteRequest,member)).doesNotThrowAnyException();
+    assertThatCode(() -> evaluationService.delete(evaluationDeleteRequest,MemberFixture.ID)).doesNotThrowAnyException();
 
   }
   @DisplayName("평가 삭제 실패 - 회원 조회 실패")
@@ -219,7 +219,7 @@ public class EvaluationServiceTest extends ServiceTest {
     given(evaluationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(evaluation));
 
     //then
-    assertThatThrownBy(() -> evaluationService.delete(evaluationDeleteRequest,member))
+    assertThatThrownBy(() -> evaluationService.delete(evaluationDeleteRequest,MemberFixture.ID))
         .isInstanceOf(MemberNotFoundException.class);
   }
 
@@ -232,9 +232,9 @@ public class EvaluationServiceTest extends ServiceTest {
     given(evaluationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(evaluation));
 
     //삭제 권한 없게 설정
-    ReflectionTestUtils.setField(evaluation,"writerId", member.getId()+1L);
+    ReflectionTestUtils.setField(evaluation,"creatorId", member.getId()+1L);
     //then
-    assertThatThrownBy(() -> evaluationService.delete(evaluationDeleteRequest,member))
+    assertThatThrownBy(() -> evaluationService.delete(evaluationDeleteRequest,MemberFixture.ID))
         .isInstanceOf(NoPermissionDeleteException.class);
   }
   @DisplayName("지원자에 대한 모든 평가 조회 성공")
@@ -252,12 +252,12 @@ public class EvaluationServiceTest extends ServiceTest {
 
     List<EvaluationResponse> expected = Arrays.asList(new EvaluationResponse(evaluation,member, APPLICATION_ID, APPLICANT_ID));
     //when
-    List<EvaluationResponse> actual = evaluationService.findAllByApplication(evaluationFindRequest,member);
+    List<EvaluationResponse> actual = evaluationService.findAllByApplication(evaluationFindRequest,MemberFixture.ID);
 
     //then
     assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
 
-    assertThatCode(() -> evaluationService.findAllByApplication(evaluationFindRequest,member)).doesNotThrowAnyException();
+    assertThatCode(() -> evaluationService.findAllByApplication(evaluationFindRequest,MemberFixture.ID)).doesNotThrowAnyException();
   }
   @DisplayName("지원자에 대한 모든 평가 조회 실패 - 회원 조회 실패")
   @Test
@@ -269,7 +269,7 @@ public class EvaluationServiceTest extends ServiceTest {
     given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(applicant));
 
     //then
-    assertThatThrownBy(() -> evaluationService.findAllByApplication(evaluationFindRequest,member))
+    assertThatThrownBy(() -> evaluationService.findAllByApplication(evaluationFindRequest,MemberFixture.ID))
         .isInstanceOf(MemberNotFoundException.class);
   }
 
@@ -283,7 +283,7 @@ public class EvaluationServiceTest extends ServiceTest {
     given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(applicant));
 
     //then
-    assertThatThrownBy(() -> evaluationService.findAllByApplication(evaluationFindRequest,member))
+    assertThatThrownBy(() -> evaluationService.findAllByApplication(evaluationFindRequest,MemberFixture.ID))
         .isInstanceOf(ApplicationNotFoundException.class);
   }
   @DisplayName("지원자에 대한 모든 평가 조회 실패 - 권한 없음(회원의 동아리와 지원서를 수정할 수 있는 동아리가 다를 경우)")
@@ -298,7 +298,7 @@ public class EvaluationServiceTest extends ServiceTest {
     //조회 권한 없게 설정
     member.addClub(new ClubMember(another,member));
     //then
-    assertThatThrownBy(() -> evaluationService.findAllByApplication(evaluationFindRequest,member))
+    assertThatThrownBy(() -> evaluationService.findAllByApplication(evaluationFindRequest,MemberFixture.ID))
         .isInstanceOf(NoPermissionReadException.class);
   }
 

--- a/src/test/java/com/modong/backend/unit/domain/evaluation/EvaluationServiceTest.java
+++ b/src/test/java/com/modong/backend/unit/domain/evaluation/EvaluationServiceTest.java
@@ -1,0 +1,305 @@
+package com.modong.backend.unit.domain.evaluation;
+
+import static com.modong.backend.Fixtures.ApplicantFixture.APPLICANT_ID;
+import static com.modong.backend.Fixtures.ApplicationFixture.APPLICATION_ID;
+import static com.modong.backend.Fixtures.ClubFixture.CLUB_ID;
+import static com.modong.backend.Fixtures.EvaluationFixture.EVALUATION_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.modong.backend.Fixtures.MemberFixture;
+import com.modong.backend.auth.member.Member;
+import com.modong.backend.domain.applicant.Applicant;
+import com.modong.backend.domain.application.Application;
+import com.modong.backend.domain.club.Club;
+import com.modong.backend.domain.club.clubMemeber.ClubMember;
+import com.modong.backend.domain.evaluation.Evaluation;
+import com.modong.backend.domain.evaluation.EvaluationService;
+import com.modong.backend.domain.evaluation.dto.EvaluationResponse;
+import com.modong.backend.global.exception.applicant.ApplicantNotFoundException;
+import com.modong.backend.global.exception.application.ApplicationNotFoundException;
+import com.modong.backend.global.exception.auth.NoPermissionCreateException;
+import com.modong.backend.global.exception.auth.NoPermissionDeleteException;
+import com.modong.backend.global.exception.auth.NoPermissionReadException;
+import com.modong.backend.global.exception.auth.NoPermissionUpdateException;
+import com.modong.backend.global.exception.member.MemberNotFoundException;
+import com.modong.backend.unit.base.ServiceTest;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class EvaluationServiceTest extends ServiceTest {
+
+  @Autowired
+  private EvaluationService evaluationService;
+
+  private Evaluation evaluation;
+
+  private Club club,another;
+  private Application application;
+  private Applicant applicant;
+  private Member member;
+
+  @BeforeEach
+  public void init(){
+
+    club = new Club(clubCreateRequest);
+    another = new Club(clubCreateRequest);
+
+    member = new Member(memberRegisterRequest);
+
+    ReflectionTestUtils.setField(member,"id", MemberFixture.ID);
+
+    application = new Application(applicationCreateRequest,club);
+
+    applicant = new Applicant(applicantCreateRequest,application);
+
+    ReflectionTestUtils.setField(club,"id", CLUB_ID);
+    ReflectionTestUtils.setField(another,"id", CLUB_ID + 1L);
+    ReflectionTestUtils.setField(application,"id", APPLICATION_ID);
+    ReflectionTestUtils.setField(applicant,"id", APPLICANT_ID);
+
+    evaluation = new Evaluation(evaluationCreateRequest_userA,member,applicant);
+
+    ReflectionTestUtils.setField(evaluation,"id", EVALUATION_ID);
+
+  }
+
+  @DisplayName("평가 생성 성공")
+  @Test
+  public void SuccessCreateEvaluation(){
+    //given
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(applicationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(application));
+    given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(applicant));
+    given(evaluationRepository.save(any())).willReturn(evaluation);
+    //생성 권한 주기
+    member.addClub(new ClubMember(club,member));
+
+
+    //when
+    Long savedId = evaluationService.create(evaluationCreateRequest_userA,MemberFixture.ID);
+
+    //then
+    assertThatCode(() -> evaluationService.create(evaluationCreateRequest_userA,MemberFixture.ID)).doesNotThrowAnyException();
+
+    assertThat(savedId).isEqualTo(EVALUATION_ID);
+  }
+  @DisplayName("평가 생성 실패 - 회원 조회 실패")
+  @Test
+  public void FailCreateEvaluation_MemberNotFound(){
+    //given, when
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.empty());
+    given(applicationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(application));
+    given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(applicant));
+
+    //then
+    assertThatThrownBy(() -> evaluationService.create(evaluationCreateRequest_userA,MemberFixture.ID))
+        .isInstanceOf(MemberNotFoundException.class);
+  }
+
+  @DisplayName("평가 생성 실패 - 지원서 조회 실패")
+  @Test
+  public void FailCreateEvaluation_ApplicationNotFound(){
+    //given, when
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(applicationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.empty());
+    given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(applicant));
+
+    //then
+    assertThatThrownBy(() -> evaluationService.create(evaluationCreateRequest_userA,MemberFixture.ID))
+        .isInstanceOf(ApplicationNotFoundException.class);
+  }
+  @DisplayName("평가 생성 실패 - 지원자 조회 실패")
+  @Test
+  public void FailCreateEvaluation_ApplicantNotFound(){
+    //given, when
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(applicationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(application));
+    given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.empty());
+
+    //then
+    assertThatThrownBy(() -> evaluationService.create(evaluationCreateRequest_userA,MemberFixture.ID))
+        .isInstanceOf(ApplicantNotFoundException.class);
+  }
+  @DisplayName("평가 생성 실패 - 권한 없음(회원의 동아리와 지원서를 수정할 수 있는 동아리가 다를 경우)")
+  @Test
+  public void FailCreateEvaluation_UnAuthorized(){
+    //given, when
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(applicationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(application));
+    given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(applicant));
+
+    //생성 권한 없는 경우
+    member.addClub(new ClubMember(another,member));
+
+    //then
+    assertThatThrownBy(() -> evaluationService.create(evaluationCreateRequest_userA,MemberFixture.ID))
+        .isInstanceOf(NoPermissionCreateException.class);
+  }
+
+  @DisplayName("평가 수정 성공")
+  @Test
+  public void SuccessUpdateEvaluation(){
+    //given
+
+    given(evaluationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(evaluation));
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(evaluationRepository.save(any())).willReturn(evaluation);
+
+    //when
+    Long savedId = evaluationService.update(evaluationUpdateRequest,MemberFixture.ID);
+
+    //then
+    assertThatCode(() -> evaluationService.update(evaluationUpdateRequest,MemberFixture.ID)).doesNotThrowAnyException();
+
+    assertThat(savedId).isEqualTo(EVALUATION_ID);
+  }
+  @DisplayName("평가 수정 실패 - 회원 조회 실패")
+  @Test
+  public void FailUpdateEvaluation_MemberNotFound(){
+    //given, when
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.empty());
+    given(evaluationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(evaluation));
+
+    //then
+    assertThatThrownBy(() -> evaluationService.update(evaluationUpdateRequest,MemberFixture.ID))
+        .isInstanceOf(MemberNotFoundException.class);
+  }
+
+  @DisplayName("평가 수정 실패 - 권한 없음(회원의 동아리와 지원서를 수정할 수 있는 동아리가 다를 경우)")
+  @Test
+  public void FailUpdateEvaluation_UnAuthorized(){
+    //given, when
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(evaluationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(evaluation));
+    //수정 권한 없게 설정
+    ReflectionTestUtils.setField(evaluation,"writerId", member.getId()+1L);
+    //then
+    assertThatThrownBy(() -> evaluationService.update(memoUpdateRequest,MemberFixture.ID))
+        .isInstanceOf(NoPermissionUpdateException.class);
+  }
+  @DisplayName("평가 삭제 성공")
+  @Test
+  public void SuccessDeleteEvaluation(){
+    //given
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(evaluationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(evaluation));
+    given(evaluationRepository.save(any())).willReturn(evaluation);
+
+    //when
+    evaluationService.delete(evaluationDeleteRequest,member);
+
+    //then
+    assertThatCode(() -> evaluationService.delete(evaluationDeleteRequest,member)).doesNotThrowAnyException();
+
+  }
+  @DisplayName("평가 삭제 실패 - 회원 조회 실패")
+  @Test
+  public void FailDeleteEvaluation_MemberNotFound(){
+    //given, when
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.empty());
+    given(evaluationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(evaluation));
+
+    //then
+    assertThatThrownBy(() -> evaluationService.delete(evaluationDeleteRequest,member))
+        .isInstanceOf(MemberNotFoundException.class);
+  }
+
+  @DisplayName("평가 삭제 실패 - 권한 없음(회원의 동아리와 지원서를 수정할 수 있는 동아리가 다를 경우)")
+  @Test
+  public void FailDeleteEvaluation_UnAuthorized(){
+    //given, when
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(evaluationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(evaluation));
+
+    //삭제 권한 없게 설정
+    ReflectionTestUtils.setField(evaluation,"writerId", member.getId()+1L);
+    //then
+    assertThatThrownBy(() -> evaluationService.delete(evaluationDeleteRequest,member))
+        .isInstanceOf(NoPermissionDeleteException.class);
+  }
+  @DisplayName("지원자에 대한 모든 평가 조회 성공")
+  @Test
+  public void SuccessFindEvaluations_ApplicationID(){
+    //given
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(applicationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(application));
+    given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(applicant));
+    given(evaluationRepository.findAllByApplicantIdAndIsDeletedIsFalse(anyLong())).willReturn(Arrays.asList(evaluation));
+
+    //조회 권한 주기
+    member.addClub(new ClubMember(club,member));
+
+    List<EvaluationResponse> expected = Arrays.asList(new EvaluationResponse(evaluation,member, APPLICATION_ID, APPLICANT_ID));
+    //when
+    List<EvaluationResponse> actual = evaluationService.findAllByApplication(evaluationFindRequest,member);
+
+    //then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+
+    assertThatCode(() -> evaluationService.findAllByApplication(evaluationFindRequest,member)).doesNotThrowAnyException();
+  }
+  @DisplayName("지원자에 대한 모든 평가 조회 실패 - 회원 조회 실패")
+  @Test
+  public void FailFindEvaluations_MemberNotFound(){
+    //given, when
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.empty());
+    given(applicationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(application));
+    given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(applicant));
+
+    //then
+    assertThatThrownBy(() -> evaluationService.findAllByApplication(evaluationFindRequest,member))
+        .isInstanceOf(MemberNotFoundException.class);
+  }
+
+  @DisplayName("지원자에 대한 모든 평가 조회 실패 - 지원서 조회 실패")
+  @Test
+  public void FailFindEvaluations_ApplicationNotFound(){
+    //given, when
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(applicationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.empty());
+    given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(applicant));
+
+    //then
+    assertThatThrownBy(() -> evaluationService.findAllByApplication(evaluationFindRequest,member))
+        .isInstanceOf(ApplicationNotFoundException.class);
+  }
+  @DisplayName("지원자에 대한 모든 평가 조회 실패 - 권한 없음(회원의 동아리와 지원서를 수정할 수 있는 동아리가 다를 경우)")
+  @Test
+  public void FailFindEvaluations_UnAuthorized(){
+    //given, when
+
+    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(member));
+    given(applicationRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(application));
+    given(applicantRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.of(applicant));
+
+    //조회 권한 없게 설정
+    member.addClub(new ClubMember(another,member));
+    //then
+    assertThatThrownBy(() -> evaluationService.findAllByApplication(evaluationFindRequest,member))
+        .isInstanceOf(NoPermissionReadException.class);
+  }
+
+}


### PR DESCRIPTION
- 회원이 평가를 추가, 삭제 , 수정할 경우 지원자에 대한 점수가 업데이트 됨.
- 평가 API는 동아리를 확인해 권한이 있는지 확인
- 삭제시 지우지는 않고 is_deleted 컬럼을 통해 체크