### PR TITLE
Feat: 인증이 필요한 API에 인증 로직 추가

### DIFF
--- a/src/main/java/com/modong/backend/config/AuthConfig.java
+++ b/src/main/java/com/modong/backend/config/AuthConfig.java
@@ -28,7 +28,7 @@ public class AuthConfig implements WebMvcConfigurer {
         .excludePathPatterns(
                 "/api/v1/club", "api/v1/club/check",
                 "/api/v1/login","/api/v1/register","/api/v1/member/check", "/api/v1/token",
-                "/api/v1/view/application/**", "/api/v1/view/form/**", "api/v1/forms/**",
+                "/api/v1/view/application/**", "/api/v1/form/**", "api/v1/forms/**",
                 "/api/v1/applicant");
   }
 

--- a/src/main/java/com/modong/backend/config/AuthConfig.java
+++ b/src/main/java/com/modong/backend/config/AuthConfig.java
@@ -24,8 +24,12 @@ public class AuthConfig implements WebMvcConfigurer {
   @Override
   public void addInterceptors(final InterceptorRegistry registry) {
     registry.addInterceptor(new AuthenticationInterceptor(jwtTokenProvider))
-        .addPathPatterns("/api/v1/member/**","/api/v1/memo/**","/api/v1/memos/**","/api/v1/evaluation/**","/api/v1/evaluations/**","/api/v1/club/member","api/v1/application","api/v1/applications")
-        .excludePathPatterns("/api/v1/login","/api/v1/register","/api/v1/member/check","api/v1/applicant","api/v1/view/application");
+        .addPathPatterns("/api/v1/**")
+        .excludePathPatterns(
+                "/api/v1/club", "api/v1/club/check",
+                "/api/v1/login","/api/v1/register","/api/v1/member/check", "/api/v1/token",
+                "/api/v1/view/application/**", "/api/v1/view/form/**", "api/v1/forms/**",
+                "/api/v1/applicant");
   }
 
 }

--- a/src/main/java/com/modong/backend/domain/applicant/Applicant.java
+++ b/src/main/java/com/modong/backend/domain/applicant/Applicant.java
@@ -68,4 +68,8 @@ public class Applicant extends BaseTimeEntity {
   public void cancelFail() {
     this.isFail = false;
   }
+  public void delete() {
+    this.isDeleted = true;
+  }
+
 }

--- a/src/main/java/com/modong/backend/domain/applicant/ApplicantController.java
+++ b/src/main/java/com/modong/backend/domain/applicant/ApplicantController.java
@@ -1,5 +1,6 @@
 package com.modong.backend.domain.applicant;
 
+import com.modong.backend.auth.support.Auth;
 import com.modong.backend.base.Dto.PageRequest;
 import com.modong.backend.domain.applicant.Dto.ApplicantDetailResponse;
 import com.modong.backend.domain.applicant.Dto.ApplicantCreateRequest;
@@ -45,9 +46,9 @@ public class ApplicantController {
   })
   //, @PageableDefault(page = 0, size = 10, sort = "id", direction = Sort.Direction.ASC), Pageable pageable)
   public ResponseEntity getApplicantsByApplicationId(@Validated @PathVariable(name="application_id") Long applicationId, @Validated
-      SearchApplicantRequest searchApplicantRequest, @Validated PageRequest pageRequest){
+      SearchApplicantRequest searchApplicantRequest, @Validated PageRequest pageRequest, @Auth Long memberId){
     Pageable pageable = pageRequest.of();
-    PageApplicantsResponse applicants = applicantService.filterByCondition(applicationId, searchApplicantRequest, pageable);
+    PageApplicantsResponse applicants = applicantService.filterByCondition(applicationId, searchApplicantRequest, pageable, memberId);
     return ResponseEntity.ok(new BaseResponse(applicants, HttpStatus.OK.value(), CustomCode.SUCCESS_GET_LIST));
   }
 
@@ -55,8 +56,8 @@ public class ApplicantController {
   @Operation(summary = "지원자 답변 조회", description = "지원자를 ID로 조회해 질문에 어떤 답을 했는지 조회 한다.", responses = {
       @ApiResponse(responseCode = "200", description = "지원자 조회 성공", content = @Content(schema = @Schema(implementation = ApplicantDetailResponse.class)))
   })
-  public ResponseEntity getApplicantById(@Validated @PathVariable(name="applicant_id") Long applicantId){
-    ApplicantDetailResponse applicant = applicantService.findById(applicantId);
+  public ResponseEntity getApplicantById(@Validated @PathVariable(name="applicant_id") Long applicantId, @Auth Long memberId){
+    ApplicantDetailResponse applicant = applicantService.findById(applicantId, memberId);
     return ResponseEntity.ok(new BaseResponse(applicant, HttpStatus.OK.value(), CustomCode.SUCCESS_GET));
   }
 
@@ -64,8 +65,8 @@ public class ApplicantController {
   @Operation(summary = "지원자 상태 변경", description = "지원자를 상태를 변경한다. ", responses = {
       @ApiResponse(responseCode = "200", description = "지원자 상태 변경 성공", content = @Content(schema = @Schema(implementation = SavedId.class)))
   })
-  public ResponseEntity changeApplicantStatus(@Validated @PathVariable(name="applicant_id") Long applicantId, @RequestBody ChangeApplicantStatusRequest applicantStatus){
-    SavedId savedId = new SavedId(applicantService.changeApplicantStatus(applicantId,applicantStatus));
+  public ResponseEntity changeApplicantStatus(@Validated @PathVariable(name="applicant_id") Long applicantId, @RequestBody ChangeApplicantStatusRequest applicantStatus, @Auth Long memberId){
+    SavedId savedId = new SavedId(applicantService.changeApplicantStatus(applicantId,applicantStatus,memberId));
     return ResponseEntity.ok(new BaseResponse(savedId, HttpStatus.OK.value(), CustomCode.SUCCESS_UPDATE));
   }
 
@@ -73,8 +74,8 @@ public class ApplicantController {
   @Operation(summary = "지원자의 탈락 상태 취소", description = "탈락인 지원자의 상태를 탈락취소로 변경한다. ", responses = {
       @ApiResponse(responseCode = "200", description = "지원자의 탈락 상태 취소", content = @Content(schema = @Schema(implementation = SavedId.class)))
   })
-  public ResponseEntity failApplicantCancel(@Validated @PathVariable(name="applicant_id") Long applicantId){
-    SavedId savedId = new SavedId(applicantService.cancelFailStatus(applicantId));
+  public ResponseEntity failApplicantCancel(@Validated @PathVariable(name="applicant_id") Long applicantId, @Auth Long memberId){
+    SavedId savedId = new SavedId(applicantService.cancelFailStatus(applicantId,memberId));
     return ResponseEntity.ok(new BaseResponse(savedId, HttpStatus.OK.value(), CustomCode.SUCCESS_UPDATE));
   }
 

--- a/src/main/java/com/modong/backend/domain/applicant/ApplicantService.java
+++ b/src/main/java/com/modong/backend/domain/applicant/ApplicantService.java
@@ -1,5 +1,7 @@
 package com.modong.backend.domain.applicant;
 
+import com.modong.backend.auth.member.Member;
+import com.modong.backend.auth.member.MemberRepository;
 import com.modong.backend.domain.applicant.Dto.ApplicantDetailResponse;
 import com.modong.backend.domain.applicant.Dto.ApplicantCreateRequest;
 import com.modong.backend.domain.applicant.Dto.ApplicantSimpleResponse;
@@ -16,11 +18,14 @@ import com.modong.backend.domain.essentialAnswer.EssentialAnswerService;
 import com.modong.backend.domain.questionAnswer.Dto.QuestionAnswerRequest;
 import com.modong.backend.domain.questionAnswer.QuestionAnswerService;
 import com.modong.backend.global.exception.IsClosed;
-import com.modong.backend.global.exception.ResourceNotFoundException;
 import com.modong.backend.global.exception.StatusBadRequestException;
 import com.modong.backend.global.exception.applicant.ApplicantNotFoundException;
 import java.util.stream.Collectors;
 import java.util.List;
+
+import com.modong.backend.global.exception.auth.NoPermissionReadException;
+import com.modong.backend.global.exception.auth.NoPermissionUpdateException;
+import com.modong.backend.global.exception.member.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -37,7 +42,7 @@ public class ApplicantService {
   private final ApplicationService applicationService;
   private final EssentialAnswerService essentialAnswerService;
   private final QuestionAnswerService questionAnswerService;
-
+  private final MemberRepository memberRepository;
   private final ApplicantRepositoryCustomImpl applicantRepositoryCustom;
 
   public List<ApplicantSimpleResponse> findAllByApplicationId(Long applicationId) {
@@ -49,27 +54,42 @@ public class ApplicantService {
 
 
   // 지원자 상세조회
-  public ApplicantDetailResponse findById(Long applicantId) {
-    ApplicantDetailResponse applicant = new ApplicantDetailResponse(applicantRepository.findById(applicantId)
-        .orElseThrow(()-> new ApplicantNotFoundException(applicantId)));
+  public ApplicantDetailResponse findById(Long applicantId, Long memberId) {
+    Member member = findMemberById(memberId);
 
-    return applicant;
+    Applicant applicant = applicantRepository.findById(applicantId)
+        .orElseThrow(()-> new ApplicantNotFoundException(applicantId));
+
+    Long clubId = applicant.getApplication().getClub().getId();
+
+    if(clubId.equals(member.getClubId())){
+      return new ApplicantDetailResponse(applicant);
+    }
+    else throw new NoPermissionReadException();
   }
   @Transactional // 지원자 상태 변경
-  public Long changeApplicantStatus(Long applicantId, ChangeApplicantStatusRequest applicantStatus){
+  public Long changeApplicantStatus(Long applicantId, ChangeApplicantStatusRequest applicantStatus, Long memberId){
+
+    Member member = findMemberById(memberId);
 
     Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(() -> new ApplicantNotFoundException(applicantId));
 
-    //Fail 이라면 현재 지원자가 어떤 상태인지는 상관하지 않고 변수 하나 추가해서 2가지 상태를 저장하도록 로직 변경
-    if(applicantStatus.getApplicantStatusCode() == ApplicantStatus.FAIL.getCode()){
-      applicant.fail();
-    }
-    else {
-      applicant.changeStatus(ApplicantStatus.valueOf(applicantStatus.getApplicantStatusCode()));
-    }
-    applicantRepository.save(applicant);
+    Long clubId = applicant.getApplication().getClub().getId();
 
-    return applicant.getId();
+    if(clubId.equals(member.getClubId())){
+      //Fail 이라면 현재 지원자가 어떤 상태인지는 상관하지 않고 변수 하나 추가해서 2가지 상태를 저장하도록 로직 변경
+      if(applicantStatus.getApplicantStatusCode() == ApplicantStatus.FAIL.getCode()){
+        applicant.fail();
+      }
+      else {
+        applicant.changeStatus(ApplicantStatus.valueOf(applicantStatus.getApplicantStatusCode()));
+      }
+      applicantRepository.save(applicant);
+
+      return applicant.getId();
+    }
+    else throw new NoPermissionUpdateException();
+
   }
   @Transactional // 지원자 생성 및 질문에 대한 답변들 저장
   public Long createApplicant(ApplicantCreateRequest applicantCreateRequest) {
@@ -100,24 +120,49 @@ public class ApplicantService {
   }
 
   public PageApplicantsResponse filterByCondition(Long applicationId,
-      SearchApplicantRequest searchApplicantRequest, Pageable pageable) {
-    Page<Applicant> applicants = applicantRepositoryCustom.searchByApplicationIdAndStatus(applicationId,searchApplicantRequest,pageable);
+                                                  SearchApplicantRequest searchApplicantRequest, Pageable pageable, Long memberId) {
+
+    Member member = findMemberById(memberId);
+
+    Application application = applicationService.findSimpleById(applicationId);
+
+    Long clubId = application.getClub().getId();
+
+    if(clubId.equals(member.getClubId())){
+      Page<Applicant> applicants = applicantRepositoryCustom.searchByApplicationIdAndStatus(applicationId,searchApplicantRequest,pageable);
 //    if(applicants.isEmpty()){
 //      throw new ResourceNotFoundException("조건에 맞는 지원자들 조회 결과 없음");
 //    }
-    return new PageApplicantsResponse(applicants);
+      return new PageApplicantsResponse(applicants);
+    }
+    else throw new NoPermissionReadException();
+
   }
 
   @Transactional
-  public Long cancelFailStatus(Long applicantId) {
+  public Long cancelFailStatus(Long applicantId, Long memberId) {
+
+    Member member = findMemberById(memberId);
+
     Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(() -> new ApplicantNotFoundException(applicantId));
-    if(applicant.isFail() == false){//탈락한 상태가 아니라면 예외 처리
-      throw new StatusBadRequestException();
+
+    Long clubId = applicant.getApplication().getClub().getId();
+
+    if(clubId.equals(member.getClubId())){
+      if(applicant.isFail() == false){//탈락한 상태가 아니라면 예외 처리
+        throw new StatusBadRequestException();
+      }
+      else{
+        applicant.cancelFail();
+      }
+      Applicant saved = applicantRepository.save(applicant);
+      return saved.getId();
     }
-    else{
-      applicant.cancelFail();
-    }
-    Applicant saved = applicantRepository.save(applicant);
-    return saved.getId();
+    else throw new NoPermissionUpdateException();
+  }
+
+  private Member findMemberById(Long memberId){
+    Member findMember = memberRepository.findByIdAndIsDeletedIsFalse(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+    return findMember;
   }
 }

--- a/src/main/java/com/modong/backend/domain/applicant/ApplicantService.java
+++ b/src/main/java/com/modong/backend/domain/applicant/ApplicantService.java
@@ -46,7 +46,7 @@ public class ApplicantService {
   private final ApplicantRepositoryCustomImpl applicantRepositoryCustom;
 
   public List<ApplicantSimpleResponse> findAllByApplicationId(Long applicationId) {
-    List<ApplicantSimpleResponse> applicants = applicantRepository.findAllByApplicationId(applicationId).stream().map(
+    List<ApplicantSimpleResponse> applicants = applicantRepository.findAllByApplicationIdAndIsDeletedIsFalse(applicationId).stream().map(
         ApplicantSimpleResponse::new).collect(
         Collectors.toList());
     return applicants;
@@ -57,7 +57,7 @@ public class ApplicantService {
   public ApplicantDetailResponse findById(Long applicantId, Long memberId) {
     Member member = findMemberById(memberId);
 
-    Applicant applicant = applicantRepository.findById(applicantId)
+    Applicant applicant = applicantRepository.findByIdAndIsDeletedIsFalse(applicantId)
         .orElseThrow(()-> new ApplicantNotFoundException(applicantId));
 
     Long clubId = applicant.getApplication().getClub().getId();
@@ -72,7 +72,7 @@ public class ApplicantService {
 
     Member member = findMemberById(memberId);
 
-    Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(() -> new ApplicantNotFoundException(applicantId));
+    Applicant applicant = applicantRepository.findByIdAndIsDeletedIsFalse(applicantId).orElseThrow(() -> new ApplicantNotFoundException(applicantId));
 
     Long clubId = applicant.getApplication().getClub().getId();
 
@@ -144,7 +144,7 @@ public class ApplicantService {
 
     Member member = findMemberById(memberId);
 
-    Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(() -> new ApplicantNotFoundException(applicantId));
+    Applicant applicant = applicantRepository.findByIdAndIsDeletedIsFalse(applicantId).orElseThrow(() -> new ApplicantNotFoundException(applicantId));
 
     Long clubId = applicant.getApplication().getClub().getId();
 

--- a/src/main/java/com/modong/backend/domain/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/modong/backend/domain/applicant/repository/ApplicantRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApplicantRepository extends JpaRepository<Applicant,Long> {
 
-  ArrayList<Applicant> findAllByApplicationId(Long applicationId);
+  ArrayList<Applicant> findAllByApplicationIdAndIsDeletedIsFalse(Long applicationId);
 
   Optional<Applicant> findByIdAndIsDeletedIsFalse(Long applicantId);
 }

--- a/src/main/java/com/modong/backend/domain/applicant/repository/ApplicantRepositoryCustomImpl.java
+++ b/src/main/java/com/modong/backend/domain/applicant/repository/ApplicantRepositoryCustomImpl.java
@@ -46,6 +46,9 @@ public class ApplicantRepositoryCustomImpl implements ApplicantRepositoryCustom{
             eqEvaluationNotDeleted()
         )
         .fetchOne();
+    if (result == null) {
+      return 0f;
+    }
     return result.floatValue();
   }
 
@@ -57,6 +60,9 @@ public class ApplicantRepositoryCustomImpl implements ApplicantRepositoryCustom{
                     eqEvaluationApplicantId(applicantId),
                     eqEvaluationNotDeleted()
             );
+    if(count.isNull().equals(Boolean.TRUE)){
+      return 0L;
+    }
     return count.fetchCount();
   }
 

--- a/src/main/java/com/modong/backend/domain/application/ApplicationController.java
+++ b/src/main/java/com/modong/backend/domain/application/ApplicationController.java
@@ -99,8 +99,8 @@ public class ApplicationController {
   @Operation(summary = "지원서 조회", description = "지원서의 링크 아이디를 이용해 작성한 지원서를 조회한다.", responses = {
       @ApiResponse(responseCode = "200", description = "지원서 조회 성공", content = @Content(schema = @Schema(implementation = ApplicationDetailResponse.class)))
   })
-  public ResponseEntity getApplicationByUrlId(@Validated @PathVariable(name = "url_id") String urlId, @Auth Long memberId){
-    ApplicationDetailResponse application = applicationService.findDetailByUrlId(urlId, memberId);
+  public ResponseEntity getApplicationByUrlId(@Validated @PathVariable(name = "url_id") String urlId){
+    ApplicationDetailResponse application = applicationService.findDetailByUrlId(urlId);
     return ResponseEntity.ok(new BaseResponse(application,HttpStatus.OK.value(), CustomCode.SUCCESS_GET));
   }
 

--- a/src/main/java/com/modong/backend/domain/application/ApplicationService.java
+++ b/src/main/java/com/modong/backend/domain/application/ApplicationService.java
@@ -148,18 +148,11 @@ public class ApplicationService {
     else throw new NoPermissionDeleteException();
   }
 
-  public ApplicationDetailResponse findDetailByUrlId(String urlId, Long memberId) {
-
-    Member member = findMemberById(memberId);
+  public ApplicationDetailResponse findDetailByUrlId(String urlId) {
 
     Application application = applicationRepository.findByUrlId(urlId).orElseThrow(() -> new ApplicationNotFoundException(urlId));
 
-    Long clubId = application.getClub().getId();
-
-    if(clubId.equals(member.getClubId())){
-      return getDetailResponse(application);
-    }
-    else throw new NoPermissionReadException();
+    return getDetailResponse(application);
   }
 
 

--- a/src/main/java/com/modong/backend/domain/form/FormController.java
+++ b/src/main/java/com/modong/backend/domain/form/FormController.java
@@ -59,9 +59,9 @@ public class FormController {
   @Operation(summary = "페이지 조회", description = "페이지의 ID를 이용해 조회한다.", responses = {
       @ApiResponse(responseCode = "200", description = "페이지 조회 성공", content = @Content(schema = @Schema(implementation = FormResponse.class)))
   })
-  public ResponseEntity getFormById(@Valid @PathVariable(name = "form_id") Long formId, @Auth Long memberId){
+  public ResponseEntity getFormById(@Valid @PathVariable(name = "form_id") Long formId){
 
-    FormResponse form = formService.findById(formId,memberId);
+    FormResponse form = formService.findById(formId);
     return ResponseEntity.ok(new BaseResponse(form,HttpStatus.OK.value(), CustomCode.SUCCESS_GET));
   }
 
@@ -70,8 +70,8 @@ public class FormController {
   @Operation(summary = "지원서 ID 로 해당되는 모든 페이지 조회", description = "지원서 ID를 이용해 포함된 모든 페이지를 조회한다.",responses = {
       @ApiResponse(responseCode = "200", description = "페이지 리스트 조회 성공", content = @Content(array = @ArraySchema(schema = @Schema(implementation = FormResponse.class))))
   })
-  public ResponseEntity getFormsByApplicationId(@Valid @PathVariable(name = "application_id") Long applicationId, @Auth Long memberId){
-    List<FormResponse> forms = formService.findAllByApplicationId(applicationId,memberId);
+  public ResponseEntity getFormsByApplicationId(@Valid @PathVariable(name = "application_id") Long applicationId){
+    List<FormResponse> forms = formService.findAllByApplicationId(applicationId);
     return ResponseEntity.ok(new BaseResponse(forms, HttpStatus.OK.value(), CustomCode.SUCCESS_GET_LIST));
   }
 

--- a/src/main/java/com/modong/backend/domain/form/FormService.java
+++ b/src/main/java/com/modong/backend/domain/form/FormService.java
@@ -58,39 +58,24 @@ public class FormService {
     else throw new NoPermissionCreateException();
   }
 
-  public FormResponse findById(Long formId, Long memberId) {
-    Member member = findMemberById(memberId);
+  public FormResponse findById(Long formId) {
 
     Form form = formRepository.findById(formId).orElseThrow(() -> new IllegalArgumentException(ERROR_REQ_PARAM_ID.toString()));
 
-    Long clubId = form.getApplication().getClub().getId();
-
-    if(clubId.equals(member.getClubId())){
-      return new FormResponse(form);
-    }
-    else throw new NoPermissionReadException();
+    return new FormResponse(form);
   }
 
-  public List<FormResponse> findAllByApplicationId(Long applicationId, Long memberId) {
+  public List<FormResponse> findAllByApplicationId(Long applicationId) {
 
-    Member member = findMemberById(memberId);
+    List<Form> forms = formRepository.findAllByApplicationId(applicationId);
 
-    Application application = applicationService.findSimpleById(applicationId);
+    List<FormResponse> results = new ArrayList<>();
 
-    Long clubId = application.getClub().getId();
-
-    if(clubId.equals(member.getClubId())){
-      List<Form> forms = formRepository.findAllByApplicationId(applicationId);
-
-      List<FormResponse> results = new ArrayList<>();
-
-      for(Form form : forms){
-        results.add(new FormResponse(form));
-      }
-
-      return results;
+    for(Form form : forms){
+      results.add(new FormResponse(form));
     }
-    else throw new NoPermissionReadException();
+
+    return results;
   }
 
   @Transactional

--- a/src/test/java/com/modong/backend/unit/domain/application/ApplicationServiceTest.java
+++ b/src/test/java/com/modong/backend/unit/domain/application/ApplicationServiceTest.java
@@ -131,15 +131,13 @@ public class ApplicationServiceTest extends ServiceTest {
   @Test
   public void SuccessReadApplication_UrlID(){
     //given
-    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.ofNullable(member));
-
     given(applicationRepository.findByUrlId(anyString())).willReturn(Optional.of(application));
 
     //when
-    ApplicationDetailResponse response = applicationService.findDetailByUrlId(URL_ID, MemberFixture.ID);
+    ApplicationDetailResponse response = applicationService.findDetailByUrlId(URL_ID);
 
     //then
-    assertThatCode(() -> applicationService.findDetailByUrlId(URL_ID, MemberFixture.ID)).doesNotThrowAnyException();
+    assertThatCode(() -> applicationService.findDetailByUrlId(URL_ID)).doesNotThrowAnyException();
 
     assertThat(response).usingRecursiveComparison().isEqualTo(new ApplicationDetailResponse(application));
   }
@@ -159,12 +157,11 @@ public class ApplicationServiceTest extends ServiceTest {
   @Test
   public void throwExceptionIfUrlIdNotFound_Read(){
     //given, when
-    given(memberRepository.findByIdAndIsDeletedIsFalse(anyLong())).willReturn(Optional.ofNullable(member));
     given(applicationRepository.findByUrlId(anyString()))
         .willReturn(Optional.empty());
 
     //then
-    assertThatThrownBy(() -> applicationService.findDetailByUrlId(URL_ID, MemberFixture.ID))
+    assertThatThrownBy(() -> applicationService.findDetailByUrlId(URL_ID))
         .isInstanceOf(ApplicationNotFoundException.class);
   }
 


### PR DESCRIPTION
- Form : 지원자가 지원서를 볼때 필요하기 때문에 해당 부분에서 Read는 권한 없어도 가능 하도록 변경
- Applicant : 지원자가 지원서를 제출 했을때 등록이 되어야 하기 때문에 권한 없이 되도록 작성

동아리 생성, 동아리 코드 검사, 로그인, 회원가입, 회원 ID 중복 검사, 토큰 재발행, 지원자가 지원서 보는 화면(view/application), 지원서 페이지(read 부분), 지원자 생성은 인증 절차 없이 API가 동작하도록 AuthConfig 파일 설정